### PR TITLE
Adds scheduled mailings, mailbox pagination, and improved command displays

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.yusaki</groupId>
     <artifactId>LamMailBox</artifactId>
-    <version>1.4.1-SNAPSHOT</version>
+    <version>1.4.2-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>LamMailBox</name>
@@ -45,6 +45,10 @@
                         <relocation>
                             <pattern>com.tcoded.folialib</pattern>
                             <shadedPattern>com.yusaki.lammailbox.lib.folialib</shadedPattern>
+                        </relocation>
+                        <relocation>
+                            <pattern>com.cronutils</pattern>
+                            <shadedPattern>com.yusaki.lammailbox.lib.cronutils</shadedPattern>
                         </relocation>
                     </relocations>
                 </configuration>
@@ -116,6 +120,11 @@
             <groupId>org.xerial</groupId>
             <artifactId>sqlite-jdbc</artifactId>
             <version>3.45.3.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.cronutils</groupId>
+            <artifactId>cron-utils</artifactId>
+            <version>9.2.0</version>
         </dependency>
     </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.yusaki</groupId>
     <artifactId>LamMailBox</artifactId>
-    <version>1.4.2-SNAPSHOT</version>
+    <version>1.5.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>LamMailBox</name>

--- a/src/main/java/com/yusaki/lammailbox/LamMailBox.java
+++ b/src/main/java/com/yusaki/lammailbox/LamMailBox.java
@@ -57,6 +57,7 @@ public class LamMailBox extends JavaPlugin implements Listener {
     private Map<UUID, Boolean> inMailCreation;
     private Map<UUID, String> deleteConfirmations;
     private Map<UUID, String> viewingAsPlayer;
+    private Map<UUID, Integer> mailViewPages;
     private FoliaLib foliaLib;
     private InventoryClickHandler inventoryClickHandler;
     private MailGuiFactory mailGuiFactory;
@@ -86,6 +87,7 @@ public class LamMailBox extends JavaPlugin implements Listener {
         inMailCreation = new HashMap<>();
         deleteConfirmations = new HashMap<>();
         viewingAsPlayer = new HashMap<>();
+        mailViewPages = new HashMap<>();
         inventoryClickHandler = new InventoryClickHandler(this);
         mailGuiFactory = new ConfigMailGuiFactory(this);
         mailCreationController = new MailCreationController(this);
@@ -516,6 +518,10 @@ public class LamMailBox extends JavaPlugin implements Listener {
 
     public Map<UUID, String> getViewingAsPlayer() {
         return viewingAsPlayer;
+    }
+
+    public Map<UUID, Integer> getMailViewPages() {
+        return mailViewPages;
     }
 
     public FoliaLib getFoliaLib() {

--- a/src/main/java/com/yusaki/lammailbox/LamMailBox.java
+++ b/src/main/java/com/yusaki/lammailbox/LamMailBox.java
@@ -455,7 +455,7 @@ public class LamMailBox extends JavaPlugin implements Listener {
 
         if (receiverSpec.equalsIgnoreCase("all")) {
             Bukkit.getOnlinePlayers().forEach(player ->
-                    sendMailNotification(player, mailId, senderName));
+                    scheduleNotification(player, mailId, senderName));
             return;
         }
 
@@ -463,14 +463,23 @@ public class LamMailBox extends JavaPlugin implements Listener {
             Arrays.stream(receiverSpec.split(";"))
                     .map(Bukkit::getPlayer)
                     .filter(Objects::nonNull)
-                    .forEach(player -> sendMailNotification(player, mailId, senderName));
+                    .forEach(player -> scheduleNotification(player, mailId, senderName));
             return;
         }
 
         Player receiver = Bukkit.getPlayer(receiverSpec);
         if (receiver != null) {
-            sendMailNotification(receiver, mailId, senderName);
+            scheduleNotification(receiver, mailId, senderName);
         }
+    }
+
+    private void scheduleNotification(Player player, String mailId, String senderName) {
+        // Schedule on player's region thread for Folia compatibility
+        foliaLib.getScheduler().runAtEntity(player, task -> {
+            if (player.isOnline()) {
+                sendMailNotification(player, mailId, senderName);
+            }
+        });
     }
 
     public void dispatchMailNotifications(String receiverSpec, String mailId, String senderName) {

--- a/src/main/java/com/yusaki/lammailbox/command/LmbTabComplete.java
+++ b/src/main/java/com/yusaki/lammailbox/command/LmbTabComplete.java
@@ -41,9 +41,6 @@ public class LmbTabComplete implements TabCompleter {
                 completions.add("send");
                 completions.add("mailings");
             }
-            if (sender.hasPermission(config.getString("settings.permissions.open"))) {
-                completions.add("view");
-            }
             if (sender.hasPermission(config.getString("settings.permissions.view-as"))) {
                 completions.add("as");
             }
@@ -76,13 +73,6 @@ public class LmbTabComplete implements TabCompleter {
                         playerNames.add("allonline");
                     }
                     return playerNames;
-                }
-            } else if (Objects.equals(subCommand, "view")) {
-                if (sender instanceof Player && sender.hasPermission(config.getString("settings.permissions.open"))) {
-                    return plugin.getMailRepository().listMailIds().stream()
-                            .filter(mailId -> mailId.toLowerCase().startsWith(current))
-                            .limit(10)
-                            .collect(Collectors.toList());
                 }
             } else {
                 if (sender.hasPermission(config.getString("settings.permissions.open-others"))) {

--- a/src/main/java/com/yusaki/lammailbox/command/LmbTabComplete.java
+++ b/src/main/java/com/yusaki/lammailbox/command/LmbTabComplete.java
@@ -39,6 +39,7 @@ public class LmbTabComplete implements TabCompleter {
             List<String> completions = new ArrayList<>();
             if (sender.hasPermission(config.getString("settings.admin-permission"))) {
                 completions.add("send");
+                completions.add("mailings");
             }
             if (sender.hasPermission(config.getString("settings.permissions.open"))) {
                 completions.add("view");

--- a/src/main/java/com/yusaki/lammailbox/config/MailBoxConfigUpdater.java
+++ b/src/main/java/com/yusaki/lammailbox/config/MailBoxConfigUpdater.java
@@ -63,7 +63,7 @@ public class MailBoxConfigUpdater {
     }
 
     // Config version - tracks configuration schema changes
-    private static final double CURRENT_CONFIG_VERSION = 1.0;
+    private static final double CURRENT_CONFIG_VERSION = 1.3;
 
     /**
      * Creates migrations for different config versions.

--- a/src/main/java/com/yusaki/lammailbox/mailing/MailingConfigLoader.java
+++ b/src/main/java/com/yusaki/lammailbox/mailing/MailingConfigLoader.java
@@ -1,0 +1,199 @@
+package com.yusaki.lammailbox.mailing;
+
+import com.yusaki.lammailbox.LamMailBox;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.configuration.file.YamlConfiguration;
+
+import java.io.File;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+
+public final class MailingConfigLoader {
+    private final LamMailBox plugin;
+    private final File file;
+
+    public MailingConfigLoader(LamMailBox plugin) {
+        this.plugin = Objects.requireNonNull(plugin, "plugin");
+        this.file = new File(plugin.getDataFolder(), "mailings.yml");
+    }
+
+    public List<MailingDefinition> load() {
+        ensureFileExists();
+        YamlConfiguration yaml = YamlConfiguration.loadConfiguration(file);
+        ConfigurationSection root = yaml.getConfigurationSection("mailings");
+        if (root == null) {
+            return Collections.emptyList();
+        }
+
+        List<MailingDefinition> definitions = new ArrayList<>();
+        for (String id : root.getKeys(false)) {
+            ConfigurationSection section = root.getConfigurationSection(id);
+            if (section == null) {
+                continue;
+            }
+            MailingDefinition definition = parseDefinition(id, section);
+            if (definition != null) {
+                definitions.add(definition);
+            }
+        }
+        return definitions;
+    }
+
+    private MailingDefinition parseDefinition(String id, ConfigurationSection section) {
+        boolean enabled = section.getBoolean("enabled", true);
+        String typeRaw = section.getString("type", "REPEATING");
+        MailingType type = MailingType.from(typeRaw, MailingType.REPEATING);
+        String message = section.getString("message");
+        if (message == null || message.isBlank()) {
+            plugin.getLogger().warning("Mailing " + id + " ignored: missing message");
+            return null;
+        }
+
+        MailingDefinition.Builder builder = MailingDefinition.builder(id)
+                .enabled(enabled)
+                .type(type)
+                .message(message)
+                .sender(section.getString("sender"))
+                .receiver(section.getString("receiver"))
+                .requiredPermission(section.getString("required-permission"))
+                .expireDays(parsePositiveInt(section, "expire-days"))
+                .itemDirectives(cleanStrings(section.getStringList("items")))
+                .commands(cleanStrings(section.getStringList("commands")));
+
+        ConfigurationSection schedule = section.getConfigurationSection("schedule");
+
+        if (type == MailingType.REPEATING) {
+            applyCronSchedule(id, builder, schedule, typeRaw);
+        } else if (type == MailingType.FIRST_JOIN) {
+            builder.firstJoinDelay(parseFirstJoinDelay(schedule));
+        }
+
+        return builder.build();
+    }
+
+    private void applyCronSchedule(String id,
+                                   MailingDefinition.Builder builder,
+                                   ConfigurationSection schedule,
+                                   String rawType) {
+        if (schedule == null) {
+            plugin.getLogger().warning("Mailing " + id + " ignored: cron mailings require schedule.cron");
+            builder.enabled(false);
+            return;
+        }
+
+        String cron = schedule.getString("cron");
+        if (cron == null || cron.isBlank()) {
+            // Legacy helpers
+            String runAt = schedule.getString("run-at");
+            if (runAt != null) {
+                Long timestamp = parseDateTime(runAt);
+                if (timestamp != null) {
+                    java.util.Calendar calendar = java.util.Calendar.getInstance(Locale.ROOT);
+                    calendar.setTimeInMillis(timestamp);
+                    cron = calendar.get(java.util.Calendar.MINUTE) + " " +
+                            calendar.get(java.util.Calendar.HOUR_OF_DAY) + " " +
+                            calendar.get(java.util.Calendar.DAY_OF_MONTH) + " " +
+                            (calendar.get(java.util.Calendar.MONTH) + 1) + " *";
+                    builder.maxRuns(1);
+                }
+            }
+        }
+
+        if (cron == null || cron.isBlank()) {
+            plugin.getLogger().warning("Mailing " + id + " ignored: missing cron expression");
+            builder.enabled(false);
+            return;
+        }
+
+        builder.cronExpression(cron);
+
+        Integer maxRuns = parsePositiveInt(schedule, "max-runs");
+        if (maxRuns != null) {
+            builder.maxRuns(maxRuns);
+        } else if ("ONE_TIME".equalsIgnoreCase(rawType)) {
+            builder.maxRuns(1);
+        }
+    }
+
+    private Duration parseFirstJoinDelay(ConfigurationSection schedule) {
+        if (schedule == null) {
+            return null;
+        }
+        Integer minutes = parsePositiveInt(schedule, "delay-minutes");
+        if (minutes != null) {
+            return Duration.ofMinutes(minutes);
+        }
+        Integer seconds = parsePositiveInt(schedule, "delay-seconds");
+        if (seconds != null) {
+            return Duration.ofSeconds(seconds);
+        }
+        return null;
+    }
+
+    private List<String> cleanStrings(List<String> input) {
+        if (input == null) {
+            return Collections.emptyList();
+        }
+        List<String> cleaned = new ArrayList<>();
+        for (String entry : input) {
+            if (entry == null) {
+                continue;
+            }
+            String trimmed = entry.trim();
+            if (!trimmed.isEmpty()) {
+                cleaned.add(trimmed);
+            }
+        }
+        return cleaned;
+    }
+
+    private Integer parsePositiveInt(ConfigurationSection section, String path) {
+        if (section == null || !section.contains(path)) {
+            return null;
+        }
+        int value = section.getInt(path, -1);
+        return value > 0 ? value : null;
+    }
+
+    private Long parseDateTime(String raw) {
+        if (raw == null || raw.isBlank()) {
+            return null;
+        }
+        try {
+            String[] parts = raw.trim().split(":");
+            if (parts.length != 5) {
+                return null;
+            }
+            int year = Integer.parseInt(parts[0]);
+            int month = Integer.parseInt(parts[1]) - 1;
+            int day = Integer.parseInt(parts[2]);
+            int hour = Integer.parseInt(parts[3]);
+            int minute = Integer.parseInt(parts[4]);
+
+            java.util.Calendar calendar = java.util.Calendar.getInstance(Locale.ROOT);
+            calendar.set(year, month, day, hour, minute, 0);
+            calendar.set(java.util.Calendar.MILLISECOND, 0);
+            return calendar.getTimeInMillis();
+        } catch (NumberFormatException ex) {
+            return null;
+        }
+    }
+
+    private void ensureFileExists() {
+        if (!file.exists()) {
+            plugin.saveResource("mailings.yml", false);
+        }
+    }
+
+    public void saveDefaultIfMissing() {
+        ensureFileExists();
+    }
+
+    public File getFile() {
+        return file;
+    }
+}

--- a/src/main/java/com/yusaki/lammailbox/mailing/MailingDefinition.java
+++ b/src/main/java/com/yusaki/lammailbox/mailing/MailingDefinition.java
@@ -1,0 +1,195 @@
+package com.yusaki.lammailbox.mailing;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+public final class MailingDefinition {
+    private final String id;
+    private final MailingType type;
+    private final boolean enabled;
+    private final String receiver;
+    private final String message;
+    private final String sender;
+    private final List<String> itemDirectives;
+    private final List<String> commands;
+    private final String cronExpression;
+    private final Integer maxRuns;
+    private final Integer expireDays;
+    private final String requiredPermission;
+    private final Duration firstJoinDelay;
+
+    private MailingDefinition(Builder builder) {
+        this.id = builder.id;
+        this.type = builder.type;
+        this.enabled = builder.enabled;
+        this.receiver = builder.receiver;
+        this.message = builder.message;
+        this.sender = builder.sender;
+        this.itemDirectives = Collections.unmodifiableList(new ArrayList<>(builder.itemDirectives));
+        this.commands = Collections.unmodifiableList(new ArrayList<>(builder.commands));
+        this.cronExpression = builder.cronExpression;
+        this.maxRuns = builder.maxRuns;
+        this.expireDays = builder.expireDays;
+        this.requiredPermission = builder.requiredPermission;
+        this.firstJoinDelay = builder.firstJoinDelay;
+    }
+
+    public String id() {
+        return id;
+    }
+
+    public MailingType type() {
+        return type;
+    }
+
+    public boolean enabled() {
+        return enabled;
+    }
+
+    public String receiver() {
+        return receiver;
+    }
+
+    public String message() {
+        return message;
+    }
+
+    public String sender() {
+        return sender;
+    }
+
+    public List<String> itemDirectives() {
+        return itemDirectives;
+    }
+
+    public List<String> commands() {
+        return commands;
+    }
+
+    public String cronExpression() {
+        return cronExpression;
+    }
+
+    public Integer maxRuns() {
+        return maxRuns;
+    }
+
+    public Integer expireDays() {
+        return expireDays;
+    }
+
+    public String requiredPermission() {
+        return requiredPermission;
+    }
+
+    public Duration firstJoinDelay() {
+        return firstJoinDelay;
+    }
+
+    public static Builder builder(String id) {
+        return new Builder(id);
+    }
+
+    public static final class Builder {
+        private final String id;
+        private MailingType type = MailingType.REPEATING;
+        private boolean enabled = true;
+        private String receiver = "all";
+        private String message = "";
+        private String sender = "Console";
+        private List<String> itemDirectives = new ArrayList<>();
+        private List<String> commands = new ArrayList<>();
+        private String cronExpression;
+        private Integer maxRuns;
+        private Integer expireDays;
+        private String requiredPermission;
+        private Duration firstJoinDelay;
+
+        private Builder(String id) {
+            this.id = Objects.requireNonNull(id, "id");
+        }
+
+        public Builder type(MailingType type) {
+            this.type = type;
+            return this;
+        }
+
+        public Builder enabled(boolean enabled) {
+            this.enabled = enabled;
+            return this;
+        }
+
+        public Builder receiver(String receiver) {
+            if (receiver != null && !receiver.isBlank()) {
+                this.receiver = receiver;
+            }
+            return this;
+        }
+
+        public Builder message(String message) {
+            if (message != null) {
+                this.message = message;
+            }
+            return this;
+        }
+
+        public Builder sender(String sender) {
+            if (sender != null && !sender.isBlank()) {
+                this.sender = sender;
+            }
+            return this;
+        }
+
+        public Builder itemDirectives(List<String> itemDirectives) {
+            if (itemDirectives != null) {
+                this.itemDirectives = new ArrayList<>(itemDirectives);
+            }
+            return this;
+        }
+
+        public Builder commands(List<String> commands) {
+            if (commands != null) {
+                this.commands = new ArrayList<>(commands);
+            }
+            return this;
+        }
+
+        public Builder expireDays(Integer expireDays) {
+            this.expireDays = expireDays;
+            return this;
+        }
+
+        public Builder requiredPermission(String requiredPermission) {
+            if (requiredPermission != null && !requiredPermission.isBlank()) {
+                this.requiredPermission = requiredPermission;
+            }
+            return this;
+        }
+
+        public Builder cronExpression(String cronExpression) {
+            if (cronExpression != null && !cronExpression.isBlank()) {
+                this.cronExpression = cronExpression.trim();
+            }
+            return this;
+        }
+
+        public Builder maxRuns(Integer maxRuns) {
+            if (maxRuns != null && maxRuns > 0) {
+                this.maxRuns = maxRuns;
+            }
+            return this;
+        }
+
+        public Builder firstJoinDelay(Duration firstJoinDelay) {
+            this.firstJoinDelay = firstJoinDelay;
+            return this;
+        }
+
+        public MailingDefinition build() {
+            return new MailingDefinition(this);
+        }
+    }
+}

--- a/src/main/java/com/yusaki/lammailbox/mailing/MailingScheduler.java
+++ b/src/main/java/com/yusaki/lammailbox/mailing/MailingScheduler.java
@@ -1,0 +1,304 @@
+package com.yusaki.lammailbox.mailing;
+
+import com.cronutils.model.Cron;
+import com.cronutils.model.definition.CronDefinition;
+import com.cronutils.model.definition.CronDefinitionBuilder;
+import com.cronutils.model.time.ExecutionTime;
+import com.cronutils.parser.CronParser;
+import com.cronutils.model.CronType;
+import com.tcoded.folialib.FoliaLib;
+import com.yusaki.lammailbox.LamMailBox;
+import com.yusaki.lammailbox.mailing.status.MailingStatusRepository;
+import com.yusaki.lammailbox.service.MailDelivery;
+import com.yusaki.lammailbox.service.MailService;
+import com.yusaki.lammailbox.session.MailCreationSession;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.OptionalLong;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public final class MailingScheduler {
+    private static final long CHECK_PERIOD_TICKS = 200L; // 10 seconds
+
+    private final LamMailBox plugin;
+    private final MailService mailService;
+    private final MailingStatusRepository statusRepository;
+    private final FoliaLib foliaLib;
+    private final CronParser cronParser;
+    private final ZoneId zoneId;
+    private volatile List<MailingDefinition> definitions = Collections.emptyList();
+    private volatile List<CronEntry> cronEntries = Collections.emptyList();
+    private volatile Map<String, CronEntry> cronEntryIndex = Collections.emptyMap();
+    private volatile List<MailingDefinition> firstJoinDefinitions = Collections.emptyList();
+    private final AtomicBoolean started = new AtomicBoolean(false);
+    private volatile boolean running;
+
+    public MailingScheduler(LamMailBox plugin,
+                            MailService mailService,
+                            MailingStatusRepository statusRepository,
+                            FoliaLib foliaLib) {
+        this.plugin = plugin;
+        this.mailService = mailService;
+        this.statusRepository = statusRepository;
+        this.foliaLib = foliaLib;
+        CronDefinition cronDefinition = CronDefinitionBuilder.instanceDefinitionFor(CronType.UNIX);
+        this.cronParser = new CronParser(cronDefinition);
+        this.zoneId = ZoneId.systemDefault();
+    }
+
+    public void start(List<MailingDefinition> initialDefinitions) {
+        rebuildSchedules(initialDefinitions);
+        if (started.compareAndSet(false, true)) {
+            running = true;
+            foliaLib.getScheduler().runTimer(this::tick, CHECK_PERIOD_TICKS, CHECK_PERIOD_TICKS);
+        }
+    }
+
+    public void updateDefinitions(List<MailingDefinition> updated) {
+        rebuildSchedules(updated);
+    }
+
+    public void shutdown() {
+        running = false;
+    }
+
+    public void handlePlayerJoin(Player player) {
+        if (!running) {
+            return;
+        }
+        boolean firstJoin = !player.hasPlayedBefore();
+        String playerName = player.getName();
+        var uuid = player.getUniqueId();
+
+        for (MailingDefinition definition : firstJoinDefinitions) {
+            if (!definition.enabled() || definition.type() != MailingType.FIRST_JOIN) {
+                continue;
+            }
+            if (!firstJoin) {
+                continue;
+            }
+            if (statusRepository.hasReceived(definition.id(), uuid)) {
+                continue;
+            }
+            if (definition.requiredPermission() != null && !player.hasPermission(definition.requiredPermission())) {
+                continue;
+            }
+
+            long now = System.currentTimeMillis();
+            statusRepository.markReceived(definition.id(), uuid, now);
+
+            Runnable delivery = () -> deliverToSinglePlayer(definition, playerName);
+            Duration delay = definition.firstJoinDelay();
+            if (delay != null && !delay.isNegative() && !delay.isZero()) {
+                long ticks = Math.max(1L, delay.toMillis() / 50L);
+                foliaLib.getScheduler().runLater(task -> delivery.run(), ticks);
+            } else {
+                submit(delivery);
+            }
+        }
+    }
+
+    private void tick() {
+        if (!running) {
+            return;
+        }
+        ZonedDateTime now = ZonedDateTime.now(zoneId);
+        for (CronEntry entry : cronEntries) {
+            handleCron(entry, now);
+        }
+    }
+
+    private void handleCron(CronEntry entry, ZonedDateTime now) {
+        MailingDefinition definition = entry.definition();
+        if (!definition.enabled()) {
+            return;
+        }
+        Integer maxRuns = definition.maxRuns();
+        int runCount = statusRepository.getRunCount(definition.id());
+        if (maxRuns != null && runCount >= maxRuns) {
+            return;
+        }
+
+        long lastRunMillis = statusRepository.getLastRun(definition.id());
+        ZonedDateTime reference = lastRunMillis > 0
+                ? ZonedDateTime.ofInstant(Instant.ofEpochMilli(lastRunMillis), zoneId)
+                : now.minusMinutes(1);
+
+        int executions = 0;
+        while (executions < 5) {
+            Optional<ZonedDateTime> nextExecution = entry.executionTime().nextExecution(reference);
+            if (nextExecution.isEmpty()) {
+                break;
+            }
+            ZonedDateTime next = nextExecution.get();
+            if (next.isAfter(now)) {
+                break;
+            }
+            if (maxRuns != null && runCount >= maxRuns) {
+                break;
+            }
+
+            if (deliverGlobal(definition).isPresent()) {
+                long scheduledMillis = next.toInstant().toEpochMilli();
+                statusRepository.setLastRun(definition.id(), scheduledMillis);
+                statusRepository.incrementRunCount(definition.id());
+                runCount++;
+            } else {
+                break;
+            }
+
+            reference = next.plusSeconds(1);
+            executions++;
+        }
+    }
+
+    private Optional<MailDelivery> deliverGlobal(MailingDefinition definition) {
+        return deliver(definition, resolveReceiver(definition.receiver()))
+                .map(delivery -> {
+                    plugin.dispatchMailNotifications(
+                            delivery.getReceiverSpec(),
+                            delivery.getMailId(),
+                            definition.sender());
+                    return delivery;
+                });
+    }
+
+    private Optional<MailDelivery> deliverToSinglePlayer(MailingDefinition definition, String playerName) {
+        return deliver(definition, playerName)
+                .map(delivery -> {
+                    plugin.dispatchMailNotifications(
+                            delivery.getReceiverSpec(),
+                            delivery.getMailId(),
+                            definition.sender());
+                    return delivery;
+                });
+    }
+
+    private java.util.Optional<MailDelivery> deliver(MailingDefinition definition, String receiver) {
+        MailCreationSession session = new MailCreationSession();
+        session.setReceiver(receiver != null && !receiver.isBlank() ? receiver : "all");
+        session.setMessage(definition.message());
+        session.setCommands(buildCommandList(definition));
+        session.setItems(Collections.emptyList());
+
+        if (definition.expireDays() != null) {
+            long expireAt = System.currentTimeMillis() + definition.expireDays() * 86_400_000L;
+            session.setExpireDate(expireAt);
+        }
+
+        if (!session.isComplete()) {
+            plugin.getLogger().warning("Skipping mailing " + definition.id() + " due to incomplete session");
+            return java.util.Optional.empty();
+        }
+
+        try {
+            MailDelivery delivery = mailService.sendConsoleMail(Bukkit.getConsoleSender(), session);
+            if (!definition.sender().equalsIgnoreCase(delivery.getSenderName())) {
+                plugin.getMailRepository().saveMail(delivery.getMailId(), java.util.Map.of("sender", definition.sender()));
+            }
+            return java.util.Optional.of(delivery);
+        } catch (IllegalArgumentException ex) {
+            plugin.getLogger().warning("Failed to send mailing " + definition.id() + ": " + ex.getMessage());
+            return java.util.Optional.empty();
+        }
+    }
+
+    private List<String> buildCommandList(MailingDefinition definition) {
+        List<String> commands = new ArrayList<>(definition.commands());
+        for (String directive : definition.itemDirectives()) {
+            commands.add(buildGiveCommand(directive));
+        }
+        return commands;
+    }
+
+    private String buildGiveCommand(String directive) {
+        String trimmed = directive.trim();
+        if (trimmed.toLowerCase(Locale.ROOT).startsWith("give ")) {
+            return trimmed.replace("{player}", "%player%").replace("${player}", "%player%");
+        }
+        return "give %player% " + trimmed;
+    }
+
+    private String resolveReceiver(String receiver) {
+        return receiver == null || receiver.isBlank() ? "all" : receiver;
+    }
+
+    private void submit(Runnable task) {
+        foliaLib.getScheduler().runNextTick(scheduledTask -> task.run());
+    }
+
+    public OptionalLong previewNextRunEpoch(String mailingId) {
+        CronEntry entry = cronEntryIndex.get(mailingId);
+        if (entry == null) {
+            return OptionalLong.empty();
+        }
+        MailingDefinition definition = entry.definition();
+        Integer maxRuns = definition.maxRuns();
+        int runCount = statusRepository.getRunCount(definition.id());
+        if (maxRuns != null && runCount >= maxRuns) {
+            return OptionalLong.empty();
+        }
+
+        long lastRunMillis = statusRepository.getLastRun(definition.id());
+        ZonedDateTime reference = lastRunMillis > 0
+                ? ZonedDateTime.ofInstant(Instant.ofEpochMilli(lastRunMillis), zoneId)
+                : ZonedDateTime.now(zoneId);
+
+        Optional<ZonedDateTime> next = entry.executionTime().nextExecution(reference);
+        return next.map(zonedDateTime -> OptionalLong.of(zonedDateTime.toInstant().toEpochMilli()))
+                .orElseGet(OptionalLong::empty);
+    }
+
+    private void rebuildSchedules(List<MailingDefinition> updated) {
+        List<MailingDefinition> snapshot = Collections.unmodifiableList(new ArrayList<>(updated));
+        this.definitions = snapshot;
+
+        List<CronEntry> cronList = new ArrayList<>();
+        Map<String, CronEntry> cronMap = new HashMap<>();
+        List<MailingDefinition> firstJoinList = new ArrayList<>();
+
+        for (MailingDefinition definition : snapshot) {
+            if (definition.type() == MailingType.FIRST_JOIN) {
+                firstJoinList.add(definition);
+                continue;
+            }
+            if (definition.type() != MailingType.REPEATING) {
+                continue;
+            }
+            String cronExpression = definition.cronExpression();
+            if (cronExpression == null || cronExpression.isBlank()) {
+                plugin.getLogger().warning("Skipping mailing " + definition.id() + " due to missing cron expression");
+                continue;
+            }
+            try {
+                Cron cron = cronParser.parse(cronExpression);
+                cron.validate();
+                ExecutionTime executionTime = ExecutionTime.forCron(cron);
+                CronEntry entry = new CronEntry(definition, executionTime);
+                cronList.add(entry);
+                cronMap.put(definition.id(), entry);
+            } catch (IllegalArgumentException ex) {
+                plugin.getLogger().warning("Invalid cron expression for mailing " + definition.id() + ": " + ex.getMessage());
+            }
+        }
+
+        this.cronEntries = Collections.unmodifiableList(cronList);
+        this.cronEntryIndex = Collections.unmodifiableMap(cronMap);
+        this.firstJoinDefinitions = Collections.unmodifiableList(firstJoinList);
+    }
+
+    private record CronEntry(MailingDefinition definition, ExecutionTime executionTime) {
+    }
+}

--- a/src/main/java/com/yusaki/lammailbox/mailing/MailingType.java
+++ b/src/main/java/com/yusaki/lammailbox/mailing/MailingType.java
@@ -1,0 +1,21 @@
+package com.yusaki.lammailbox.mailing;
+
+public enum MailingType {
+    REPEATING,
+    FIRST_JOIN;
+
+    public static MailingType from(String raw, MailingType fallback) {
+        if (raw == null) {
+            return fallback;
+        }
+        String normalized = raw.trim().toUpperCase();
+        if ("ONE_TIME".equals(normalized) || "CRON".equals(normalized)) {
+            return REPEATING;
+        }
+        try {
+            return MailingType.valueOf(normalized);
+        } catch (IllegalArgumentException ex) {
+            return fallback;
+        }
+    }
+}

--- a/src/main/java/com/yusaki/lammailbox/mailing/status/MailingStatusRepository.java
+++ b/src/main/java/com/yusaki/lammailbox/mailing/status/MailingStatusRepository.java
@@ -1,0 +1,31 @@
+package com.yusaki.lammailbox.mailing.status;
+
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+
+public interface MailingStatusRepository {
+    long getLastRun(String mailingId);
+
+    void setLastRun(String mailingId, long timestamp);
+
+    int getRunCount(String mailingId);
+
+    void incrementRunCount(String mailingId);
+
+    Optional<Long> getLastRunForPlayer(String mailingId, UUID playerId);
+
+    void setLastRunForPlayer(String mailingId, UUID playerId, long timestamp);
+
+    boolean hasReceived(String mailingId, UUID playerId);
+
+    void markReceived(String mailingId, UUID playerId, long timestamp);
+
+    void flush();
+
+    void purgeMissingMailings(Set<String> activeIds);
+
+    default void shutdown() {
+        flush();
+    }
+}

--- a/src/main/java/com/yusaki/lammailbox/mailing/status/MailingStatusRepository.java
+++ b/src/main/java/com/yusaki/lammailbox/mailing/status/MailingStatusRepository.java
@@ -13,6 +13,15 @@ public interface MailingStatusRepository {
 
     void incrementRunCount(String mailingId);
 
+    /**
+     * Atomically increments the run count if it is below the specified maximum.
+     *
+     * @param mailingId the mailing identifier
+     * @param maxRuns the maximum number of runs allowed
+     * @return true if incremented, false if already at or above maxRuns
+     */
+    boolean incrementRunCountIfBelow(String mailingId, int maxRuns);
+
     Optional<Long> getLastRunForPlayer(String mailingId, UUID playerId);
 
     void setLastRunForPlayer(String mailingId, UUID playerId, long timestamp);
@@ -20,6 +29,16 @@ public interface MailingStatusRepository {
     boolean hasReceived(String mailingId, UUID playerId);
 
     void markReceived(String mailingId, UUID playerId, long timestamp);
+
+    /**
+     * Atomically marks a player as having received a mailing if not already marked.
+     *
+     * @param mailingId the mailing identifier
+     * @param playerId the player UUID
+     * @param timestamp the time of receipt
+     * @return true if newly marked, false if player had already received this mailing
+     */
+    boolean markReceivedIfNew(String mailingId, UUID playerId, long timestamp);
 
     void flush();
 

--- a/src/main/java/com/yusaki/lammailbox/mailing/status/SqliteMailingStatusRepository.java
+++ b/src/main/java/com/yusaki/lammailbox/mailing/status/SqliteMailingStatusRepository.java
@@ -1,0 +1,232 @@
+package com.yusaki.lammailbox.mailing.status;
+
+import com.yusaki.lammailbox.LamMailBox;
+import org.sqlite.SQLiteDataSource;
+
+import java.nio.file.Path;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+
+public final class SqliteMailingStatusRepository implements MailingStatusRepository {
+    private static final String GLOBAL_KEY = "__GLOBAL__";
+
+    private final LamMailBox plugin;
+    private final SQLiteDataSource dataSource;
+
+    public SqliteMailingStatusRepository(LamMailBox plugin, Path databasePath) {
+        this.plugin = plugin;
+        this.dataSource = new SQLiteDataSource();
+        this.dataSource.setUrl("jdbc:sqlite:" + databasePath.toAbsolutePath());
+        initialize();
+    }
+
+    private void initialize() {
+        try (Connection connection = getConnection(); Statement statement = connection.createStatement()) {
+            statement.executeUpdate("CREATE TABLE IF NOT EXISTS mailing_status ("
+                    + "mailing_id TEXT NOT NULL,"
+                    + "player_uuid TEXT NOT NULL,"
+                    + "last_sent INTEGER NOT NULL,"
+                    + "run_count INTEGER NOT NULL DEFAULT 0,"
+                    + "PRIMARY KEY (mailing_id, player_uuid))");
+            ensureRunCountColumn(connection);
+        } catch (SQLException ex) {
+            plugin.getLogger().severe("Failed to initialize mailing status table: " + ex.getMessage());
+        }
+    }
+
+    private void ensureRunCountColumn(Connection connection) {
+        try (ResultSet rs = connection.getMetaData().getColumns(null, null, "mailing_status", "run_count")) {
+            if (rs.next()) {
+                return;
+            }
+        } catch (SQLException ignored) {
+        }
+
+        try (Statement statement = connection.createStatement()) {
+            statement.executeUpdate("ALTER TABLE mailing_status ADD COLUMN run_count INTEGER NOT NULL DEFAULT 0");
+        } catch (SQLException ex) {
+            plugin.getLogger().warning("Failed to add run_count column to mailing_status: " + ex.getMessage());
+        }
+    }
+
+    private Connection getConnection() throws SQLException {
+        Connection connection = dataSource.getConnection();
+        try (Statement pragma = connection.createStatement()) {
+            pragma.execute("PRAGMA foreign_keys = ON");
+        }
+        return connection;
+    }
+
+    @Override
+    public long getLastRun(String mailingId) {
+        String sql = "SELECT last_sent FROM mailing_status WHERE mailing_id = ? AND player_uuid = ?";
+        try (Connection connection = getConnection();
+             PreparedStatement ps = connection.prepareStatement(sql)) {
+            ps.setString(1, mailingId);
+            ps.setString(2, GLOBAL_KEY);
+            try (ResultSet rs = ps.executeQuery()) {
+                if (rs.next()) {
+                    return rs.getLong("last_sent");
+                }
+            }
+        } catch (SQLException ex) {
+            plugin.getLogger().warning("Failed to read last run for mailing " + mailingId + ": " + ex.getMessage());
+        }
+        return 0L;
+    }
+
+    @Override
+    public void setLastRun(String mailingId, long timestamp) {
+        try (Connection connection = getConnection()) {
+            ensureRow(connection, mailingId, null);
+            try (PreparedStatement ps = connection.prepareStatement(
+                    "UPDATE mailing_status SET last_sent = ? WHERE mailing_id = ? AND player_uuid = ?")) {
+                ps.setLong(1, timestamp);
+                ps.setString(2, mailingId);
+                ps.setString(3, GLOBAL_KEY);
+                ps.executeUpdate();
+            }
+        } catch (SQLException ex) {
+            plugin.getLogger().warning("Failed to set last run for mailing " + mailingId + ": " + ex.getMessage());
+        }
+    }
+
+    @Override
+    public int getRunCount(String mailingId) {
+        String sql = "SELECT run_count FROM mailing_status WHERE mailing_id = ? AND player_uuid = ?";
+        try (Connection connection = getConnection();
+             PreparedStatement ps = connection.prepareStatement(sql)) {
+            ps.setString(1, mailingId);
+            ps.setString(2, GLOBAL_KEY);
+            try (ResultSet rs = ps.executeQuery()) {
+                if (rs.next()) {
+                    return rs.getInt("run_count");
+                }
+            }
+        } catch (SQLException ex) {
+            plugin.getLogger().warning("Failed to read run count for mailing " + mailingId + ": " + ex.getMessage());
+        }
+        return 0;
+    }
+
+    @Override
+    public void incrementRunCount(String mailingId) {
+        try (Connection connection = getConnection()) {
+            ensureRow(connection, mailingId, null);
+            try (PreparedStatement ps = connection.prepareStatement(
+                    "UPDATE mailing_status SET run_count = run_count + 1 WHERE mailing_id = ? AND player_uuid = ?")) {
+                ps.setString(1, mailingId);
+                ps.setString(2, GLOBAL_KEY);
+                ps.executeUpdate();
+            }
+        } catch (SQLException ex) {
+            plugin.getLogger().warning("Failed to increment run count for mailing " + mailingId + ": " + ex.getMessage());
+        }
+    }
+
+    @Override
+    public Optional<Long> getLastRunForPlayer(String mailingId, UUID playerId) {
+        String sql = "SELECT last_sent FROM mailing_status WHERE mailing_id = ? AND player_uuid = ?";
+        try (Connection connection = getConnection();
+             PreparedStatement ps = connection.prepareStatement(sql)) {
+            ps.setString(1, mailingId);
+            ps.setString(2, playerId.toString());
+            try (ResultSet rs = ps.executeQuery()) {
+                if (rs.next()) {
+                    return Optional.of(rs.getLong("last_sent"));
+                }
+            }
+        } catch (SQLException ex) {
+            plugin.getLogger().warning("Failed to read player run for mailing " + mailingId + ": " + ex.getMessage());
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    public void setLastRunForPlayer(String mailingId, UUID playerId, long timestamp) {
+        try (Connection connection = getConnection()) {
+            ensureRow(connection, mailingId, playerId);
+            try (PreparedStatement ps = connection.prepareStatement(
+                    "UPDATE mailing_status SET last_sent = ? WHERE mailing_id = ? AND player_uuid = ?")) {
+                ps.setLong(1, timestamp);
+                ps.setString(2, mailingId);
+                ps.setString(3, playerId.toString());
+                ps.executeUpdate();
+            }
+        } catch (SQLException ex) {
+            plugin.getLogger().warning("Failed to set player run for mailing " + mailingId + ": " + ex.getMessage());
+        }
+    }
+
+    @Override
+    public boolean hasReceived(String mailingId, UUID playerId) {
+        String sql = "SELECT 1 FROM mailing_status WHERE mailing_id = ? AND player_uuid = ?";
+        try (Connection connection = getConnection();
+             PreparedStatement ps = connection.prepareStatement(sql)) {
+            ps.setString(1, mailingId);
+            ps.setString(2, playerId.toString());
+            try (ResultSet rs = ps.executeQuery()) {
+                return rs.next();
+            }
+        } catch (SQLException ex) {
+            plugin.getLogger().warning("Failed to check player receipt for mailing " + mailingId + ": " + ex.getMessage());
+        }
+        return false;
+    }
+
+    @Override
+    public void markReceived(String mailingId, UUID playerId, long timestamp) {
+        setLastRunForPlayer(mailingId, playerId, timestamp);
+    }
+
+    @Override
+    public void flush() {
+        // no-op
+    }
+
+    private void ensureRow(Connection connection, String mailingId, UUID playerId) throws SQLException {
+        String sql = "INSERT INTO mailing_status (mailing_id, player_uuid, last_sent, run_count) VALUES (?, ?, 0, 0) "
+                + "ON CONFLICT(mailing_id, player_uuid) DO NOTHING";
+        try (PreparedStatement ps = connection.prepareStatement(sql)) {
+            ps.setString(1, mailingId);
+            ps.setString(2, playerId == null ? GLOBAL_KEY : playerId.toString());
+            ps.executeUpdate();
+        }
+    }
+
+    @Override
+    public void purgeMissingMailings(Set<String> activeIds) {
+        String sql = activeIds.isEmpty()
+                ? "DELETE FROM mailing_status"
+                : "DELETE FROM mailing_status WHERE mailing_id NOT IN (" + placeholders(activeIds.size()) + ")";
+        try (Connection connection = getConnection();
+             PreparedStatement ps = connection.prepareStatement(sql)) {
+            if (!activeIds.isEmpty()) {
+                int index = 1;
+                for (String id : activeIds) {
+                    ps.setString(index++, id);
+                }
+            }
+            ps.executeUpdate();
+        } catch (SQLException ex) {
+            plugin.getLogger().warning("Failed to purge mailing status entries: " + ex.getMessage());
+        }
+    }
+
+    private String placeholders(int count) {
+        StringBuilder builder = new StringBuilder();
+        for (int i = 0; i < count; i++) {
+            if (i > 0) {
+                builder.append(',');
+            }
+            builder.append('?');
+        }
+        return builder.toString();
+    }
+}

--- a/src/main/java/com/yusaki/lammailbox/mailing/status/YamlMailingStatusRepository.java
+++ b/src/main/java/com/yusaki/lammailbox/mailing/status/YamlMailingStatusRepository.java
@@ -1,0 +1,124 @@
+package com.yusaki.lammailbox.mailing.status;
+
+import com.yusaki.lammailbox.LamMailBox;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.configuration.file.YamlConfiguration;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+
+public final class YamlMailingStatusRepository implements MailingStatusRepository {
+    private final LamMailBox plugin;
+    private final File file;
+    private final YamlConfiguration yaml;
+
+    public YamlMailingStatusRepository(LamMailBox plugin) {
+        this.plugin = plugin;
+        this.file = new File(plugin.getDataFolder(), "mailing-status.yml");
+        if (!file.exists()) {
+            try {
+                file.createNewFile();
+            } catch (IOException e) {
+                plugin.getLogger().warning("Unable to create mailing-status.yml: " + e.getMessage());
+            }
+        }
+        this.yaml = YamlConfiguration.loadConfiguration(file);
+    }
+
+    @Override
+    public synchronized long getLastRun(String mailingId) {
+        return yaml.getLong(nodePath(mailingId, "last-run"), 0L);
+    }
+
+    @Override
+    public synchronized void setLastRun(String mailingId, long timestamp) {
+        ensureMailingSection(mailingId);
+        yaml.set(nodePath(mailingId, "last-run"), timestamp);
+        saveQuietly();
+    }
+
+    @Override
+    public synchronized int getRunCount(String mailingId) {
+        return yaml.getInt(nodePath(mailingId, "run-count"), 0);
+    }
+
+    @Override
+    public synchronized void incrementRunCount(String mailingId) {
+        ensureMailingSection(mailingId);
+        String path = nodePath(mailingId, "run-count");
+        int current = yaml.getInt(path, 0) + 1;
+        yaml.set(path, current);
+        saveQuietly();
+    }
+
+    @Override
+    public synchronized Optional<Long> getLastRunForPlayer(String mailingId, UUID playerId) {
+        String path = nodePath(mailingId, "players." + playerId);
+        if (!yaml.contains(path)) {
+            return Optional.empty();
+        }
+        return Optional.of(yaml.getLong(path));
+    }
+
+    @Override
+    public synchronized void setLastRunForPlayer(String mailingId, UUID playerId, long timestamp) {
+        ensureMailingSection(mailingId);
+        yaml.set(nodePath(mailingId, "players." + playerId), timestamp);
+        saveQuietly();
+    }
+
+    @Override
+    public synchronized boolean hasReceived(String mailingId, UUID playerId) {
+        return yaml.contains(nodePath(mailingId, "players." + playerId));
+    }
+
+    @Override
+    public synchronized void markReceived(String mailingId, UUID playerId, long timestamp) {
+        setLastRunForPlayer(mailingId, playerId, timestamp);
+    }
+
+    @Override
+    public synchronized void flush() {
+        saveQuietly();
+    }
+
+    @Override
+    public synchronized void purgeMissingMailings(Set<String> activeIds) {
+        ConfigurationSection root = yaml.getConfigurationSection("mailings");
+        if (root == null) {
+            return;
+        }
+        boolean changed = false;
+        for (String key : root.getKeys(false)) {
+            if (!activeIds.contains(key)) {
+                yaml.set("mailings." + key, null);
+                changed = true;
+            }
+        }
+        if (changed) {
+            saveQuietly();
+        }
+    }
+
+    private void saveQuietly() {
+        try {
+            yaml.save(file);
+        } catch (IOException e) {
+            plugin.getLogger().warning("Failed to save mailing-status.yml: " + e.getMessage());
+        }
+    }
+
+    private String nodePath(String mailingId, String suffix) {
+        return "mailings." + mailingId + "." + suffix;
+    }
+
+    private void ensureMailingSection(String mailingId) {
+        String base = "mailings." + mailingId;
+        if (!yaml.contains(base)) {
+            yaml.createSection(base);
+        }
+    }
+}

--- a/src/main/java/com/yusaki/lammailbox/service/DefaultMailService.java
+++ b/src/main/java/com/yusaki/lammailbox/service/DefaultMailService.java
@@ -28,13 +28,15 @@ public class DefaultMailService implements MailService {
     public MailDelivery sendMail(Player sender, MailCreationSession session) {
         validateSession(session);
         boolean isAdminMail = sender.hasPermission(config().getString("settings.admin-permission"));
-        return persistMail(sender.getName(), session, isAdminMail, session.getItems());
+        List<ItemStack> items = session.getItems() != null ? session.getItems() : Collections.emptyList();
+        return persistMail(sender.getName(), session, isAdminMail, items);
     }
 
     @Override
     public MailDelivery sendConsoleMail(CommandSender sender, MailCreationSession session) {
         validateSession(session);
-        return persistMail(sender.getName(), session, true, Collections.emptyList());
+        List<ItemStack> items = session.getItems() != null ? session.getItems() : Collections.emptyList();
+        return persistMail(sender.getName(), session, true, items);
     }
 
     @Override

--- a/src/main/java/com/yusaki/lammailbox/service/DefaultMailService.java
+++ b/src/main/java/com/yusaki/lammailbox/service/DefaultMailService.java
@@ -169,11 +169,11 @@ public class DefaultMailService implements MailService {
 
         if (session.getCommandBlock() != null) {
             data.put("command-block", ItemSerialization.serializeItem(session.getCommandBlock()));
-            data.put("commands", new ArrayList<>(session.getCommands()));
         } else {
             data.put("command-block", null);
-            data.put("commands", new ArrayList<String>());
         }
+        List<String> commands = session.getCommands() != null ? new ArrayList<>(session.getCommands()) : new ArrayList<>();
+        data.put("commands", commands);
 
         repository.saveMail(mailId, data);
         repository.saveMailItems(mailId, items);

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,4 +1,4 @@
-version: 1.1
+version: 1.2
 
 settings:
   max-mails-per-player: 54
@@ -147,9 +147,14 @@ gui:
         enabled: true
         slots: [10,11,12,13,14,15,16,19,20,21,22,23,24,25,28,29,30,31,32,33,34]
 
-      command-block:
+      command-item:
         enabled: true
-        slot: 0
+        material: COMMAND_BLOCK
+        name: '&6Console Action #%index%'
+        lore:
+          - '&7Command: &f%summary%'
+          - '&7Runs a server command when claimed.'
+          - '&7Total commands: &f%total%'
 
       delete-button:
         enabled: true
@@ -280,9 +285,14 @@ gui:
         enabled: true
         slots: [10,11,12,13,14,15,16,19,20,21,22,23,24,25,28,29,30,31,32,33,34]
 
-      command-block:
+      command-item:
         enabled: true
-        slot: 4
+        material: COMMAND_BLOCK
+        name: '&6Console Action #%index%'
+        lore:
+          - '&7Command: &f%summary%'
+          - '&7Runs a hidden server command.'
+          - '&7Total commands: &f%total%'
 
       claim-button:
         enabled: true
@@ -315,8 +325,6 @@ messages:
   items-claimed: '&a✔ Items claimed and added to your inventory!'
   enter-command: '&a⌘ Enter your command below (without the /)'
   incomplete-mail: '&c⚠ Cannot send mail - some details are missing!'
-  command-prefix: '&e⌘ Commands:'
-  command-format-display: '&7➜ /%command%'
   current-receiver: '&a✉ Sending to: &f%receiver%'
   current-message: '&a✎ Your message:'
   items-added: '&a✔ Added %amount% items to mail'

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -288,11 +288,28 @@ gui:
       command-item:
         enabled: true
         material: COMMAND_BLOCK
-        name: '&6Console Action #%index%'
+        name: '&6Command'
         lore:
-          - '&7Command: &f%summary%'
-          - '&7Runs a hidden server command.'
-          - '&7Total commands: &f%total%'
+          - '&7Executes when claimed'
+
+      pagination:
+        previous-button:
+          enabled: true
+          material: ARROW
+          name: '&e← Previous'
+          slot: 39
+
+        next-button:
+          enabled: true
+          material: ARROW
+          name: '&eNext →'
+          slot: 41
+
+        page-indicator:
+          enabled: true
+          material: BOOK
+          name: '&6Page %current%/%total%'
+          slot: 40
 
       claim-button:
         enabled: true

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,4 +1,4 @@
-version: 1.2
+version: 1.3
 
 settings:
   max-mails-per-player: 54

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -25,6 +25,9 @@ settings:
   command-aliases:
     base: [mailbox, mail, mb]
 
+mailings:
+  auto-cleanup: true
+
 gui:
   main:
     title: '&8ᴍᴀɪʟʙᴏx'

--- a/src/main/resources/mailings.yml
+++ b/src/main/resources/mailings.yml
@@ -9,7 +9,7 @@ mailings:
   # receiver: Target spec (player name, semicolon list, "all", etc.). Defaults to "all".
   # required-permission: Optional permission node players must have to receive the mail.
   # expire-days: Optional integer; how many days until the mail auto-expires (null = config default).
-  # items: List of item directives converted into /give commands (see buildGiveCommand helper).
+  # items: List of item directives converted directly into ItemStacks (supports namespace ids).
   # commands: Console commands executed when the mail is claimed (supports %player% placeholder).
   # schedule:
   #   For FIRST_JOIN:

--- a/src/main/resources/mailings.yml
+++ b/src/main/resources/mailings.yml
@@ -1,0 +1,64 @@
+mailings:
+  # === COMMON FIELDS ===
+  # enabled: true/false toggle for the mailing.
+  # type: FIRST_JOIN | REPEATING
+  #   FIRST_JOIN  -> fires when a player joins for the first time (per UUID).
+  #   REPEATING   -> follows the cron schedule defined under schedule.cron.
+  # message: The text stored in the mail body (supports color codes like &a).
+  # sender: Name shown as the mail sender (defaults to "Console" if omitted).
+  # receiver: Target spec (player name, semicolon list, "all", etc.). Defaults to "all".
+  # required-permission: Optional permission node players must have to receive the mail.
+  # expire-days: Optional integer; how many days until the mail auto-expires (null = config default).
+  # items: List of item directives converted into /give commands (see buildGiveCommand helper).
+  # commands: Console commands executed when the mail is claimed (supports %player% placeholder).
+  # schedule:
+  #   For FIRST_JOIN:
+  #     delay-minutes / delay-seconds (optional) -> wait before delivering after first join.
+  #   For CRON:
+  #     cron: UNIX cron expression "m h dom mon dow" (required).
+  #     max-runs: Optional positive integer to limit total executions (1 = run once).
+
+  # --- Example 1: New player welcome mail ---
+  welcome-new-players:
+    enabled: false
+    type: FIRST_JOIN
+    message: "&aWelcome to the server!"
+    sender: "Server"
+    expire-days: 7
+    items:
+      - "minecraft:cookie 16"  # Give 16 cookies when claiming the mail.
+    commands:
+      - "title %player% subtitle {\"text\":\"Check /mailbox for a welcome gift!\",\"color\":\"gold\"}"
+    schedule:
+      delay-seconds: 10        # Wait 10 seconds after first join before sending.
+
+  # --- Example 2: Daily reward for everyone at 18:00 server time ---
+  daily-reward:
+    enabled: false
+    type: REPEATING
+    receiver: "all"
+    message: "&eYour daily reward is waiting!"
+    sender: "Server"
+    expire-days: 3
+    items:
+      - "minecraft:diamond 1"
+    commands: []
+    schedule:
+      cron: "0 18 * * *"       # Minute Hour DOM Month DOW -> 18:00 every day.
+      # max-runs omitted -> repeats forever.
+
+  # --- Example 3: Single launch announcement, runs once on Jan 1 at 12:00 ---
+  launch-announcement:
+    enabled: false
+    type: REPEATING
+    receiver: "all"
+    message: "&6Server launch celebration!"
+    sender: "Server"
+    expire-days: 14
+    items:
+      - "minecraft:emerald 3"
+    commands:
+      - "broadcast Server is live!"
+    schedule:
+      cron: "0 12 1 1 *"       # Noon on January 1.
+      max-runs: 1              # Limit to a single execution.


### PR DESCRIPTION
### Summary

- Introduces scheduled mailings ("mailings") with support for cron/first-join triggers, item/command delivery, permission requirements, and status persistence via YAML or SQLite.
- Implements a flexible mailing scheduler using cron expressions (`cron-utils`), supporting once-off, recurring, and first-join mail events.
- Integrates mailing configuration (`mailings.yml`) with example templates, and auto-cleanup of old mailing state.
- Adds inventory pagination to the mail viewing GUI, enabling navigation for mails containing large numbers of items or commands.
- Refactors console command actions in mail GUI to display as configurable items with clear labels and tooltips.
- Enhances admin UX by introducing a `/lmb mailings` command to inspect current and scheduled mailings with rich status feedback.
- Updates notification and callback execution for full compatibility with async/Folia servers, ensuring thread safety.
- Improves persistence and atomicity of mailing status updates, reducing race conditions.
- Bumps version to `1.5.0-SNAPSHOT` and updates config schema version.

### Notable Improvements

- **Massively configurable mail automation** for events, onboarding, and regular player engagement.
- **Scalable mailbox UI** that remains usable even with large reward packs or batch-sent items.
- **Better item/command representation** so users understand what reward actions will take place.
- **Robust persistence and compatibility** across different storage types and server platforms.

---
- [x] Increases usability for servers with large automated mailings or custom reward packs
- [x] Maintains backward-compatibility with existing config and invokes migrations where necessary

Relates to `feat/mailings`