### PR TITLE
Introduces GUI-based creation for rich command items in mail

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,23 +5,37 @@ LamMailBox lets admins deliver items and rich-text messages to players who don�
 * **Offline delivery**: Send mail and item attachments to any player, anytime. Items stay server-side until claimed.
 * **Command-friendly**: Use `/lmb send` directly or call it from other plugins to automate rewards, gifts, or event drops.
 * **Simple GUI**: Players browse, read, and claim mail through an intuitive interface with inventory checks on pickup.
-* **Rich messages**: Supports colour codes and `\n` line breaks.
+* **Rich messages**: Supports color codes and `\n` line breaks.
 * **Admin tools**: Optional console commands execute when mail is claimed. Schedule or expire mail using `YYYY:MM:DD:HH:mm`.
 * **Bulk targets**: `player1;player2`, `allonline` (current online players), or `all` (remains until everyone claims).
 * **Flexible storage**: Choose between YAML or SQLite backends. SQLite recommended for high-volume servers (1000+ mails).
 * **Notifications**: Chat, title, and sound alerts for new mail and join reminders.
 * **Folia/Paper ready**: Uses bundled FoliaLib scheduler for smooth cross-platform timing.
+* **Mailings dashboard**: `/lmb mailings` lists recurring jobs with status colors, run history, and human-readable schedules.
+
+## Mailings Command
+
+`/lmb mailings` shows every configured mailing job so you can audit schedules without opening configuration files.
+
+### Output at a glance
+
+- **Header** – configurable banner pulled from `messages.mailings.header`.
+- **Status** – green when enabled, red when disabled; formatting comes from `messages.mailings.status-enabled` / `status-disabled`.
+- **Schedule** – repeating mailings translate their cron expression to plain language (for example, "Every day at 02:00").
+- **Next / Last run** – timestamps generated from stored run data; missing values fall back to `messages.mailings.value-missing`.
+- **Runs** – whenever `max-runs` is set, the command displays the current count and highlights when the mailing has completed.
+- **First-join mailings** – flagged with a simplified template that keeps output tidy.
+
+### Customizing the layout
+
+All strings live under `messages.mailings` in `config.yml`, so you can localize the header, list templates, and fallback text. Reload the plugin (`/lmbreload`) after editing to pick up changes instantly.
 
 ![main page](https://cdn.modrinth.com/data/cached_images/27a045c3d426870f8941d9d3ca1e7b0282d3a900_0.webp)
 ![mail creation page](https://cdn.modrinth.com/data/cached_images/8f6c3a33f10f14d70cdd1221b8c5c716a071d9fb_0.webp)
 
 ## Limitations & Roadmap
 
-
 * No cross-server syncing or Bungee/Velocity support yet.
-* `allonline` sends only to players online at send time.
-* Mail files are plain text; staff can read or edit them.
-* Command attachments always run as console commands—review for security.
 
 ## Commands
 
@@ -32,6 +46,7 @@ LamMailBox lets admins deliver items and rich-text messages to players who don�
 | `/lmb view <id>`               | *(no permission)*        | View mail by ID (if you can access it) |
 | `/lmb as <player>`             | `lammailbox.view.as`     | View mail UI as another player   |
 | `/lmb send <player> <message>` | `lammailbox.admin`       | Send mail via command or console |
+| `/lmb mailings`                | `lammailbox.admin`       | Show scheduled mailings with status |
 | `/lmbreload`                   | `lammailbox.reload`      | Reload configuration files       |
 | `/lmbmigrate <from> <to>`      | `lammailbox.migrate`     | Migrate mail between storage backends (yaml/sqlite) |
 
@@ -48,9 +63,83 @@ LamMailBox lets admins deliver items and rich-text messages to players who don�
 ## Setup
 
 1. Drop the jar in `plugins/` and start the server to generate config/database files.
-2. Edit `plugins/LamMailBox/config.yml` to customize GUI text, slots, and notification settings. Set `enabled: false` on any button entry to remove it from the interface. Decoration fillers (new in v1.3.0) can also run console commands via the `commands` list, with `%player%` and `%uuid%` placeholders.
+2. Edit `plugins/LamMailBox/config.yml` to customize GUI text, slots, notification settings, and the mailings output templates under `messages.mailings`. Set `enabled: false` on any button entry to remove it from the interface. Decoration fillers can also run console commands via the `commands` list, with `%player%` and `%uuid%` placeholders.
 3. Grant the permissions that fit your ranks.
 4. Compose mail through the GUI or use `/lmb send` (or another plugin trigger) for automated deliveries.
+
+## Default `mailings.yml`
+
+<details>
+<summary>Show default <code>mailings.yml</code></summary>
+
+```yaml
+mailings:
+  # === COMMON FIELDS ===
+  # enabled: true/false toggle for the mailing.
+  # type: FIRST_JOIN | REPEATING
+  #   FIRST_JOIN  -> fires when a player joins for the first time (per UUID).
+  #   REPEATING   -> follows the cron schedule defined under schedule.cron.
+  # message: The text stored in the mail body (supports color codes like &a).
+  # sender: Name shown as the mail sender (defaults to "Console" if omitted).
+  # receiver: Target spec (player name, semicolon list, "all", etc.). Defaults to "all".
+  # required-permission: Optional permission node players must have to receive the mail.
+  # expire-days: Optional integer; how many days until the mail auto-expires (null = config default).
+  # items: List of item directives converted directly into ItemStacks (supports namespace ids).
+  # commands: Console commands executed when the mail is claimed (supports %player% placeholder).
+  # schedule:
+  #   For FIRST_JOIN:
+  #     delay-minutes / delay-seconds (optional) -> wait before delivering after first join.
+  #   For CRON:
+  #     cron: UNIX cron expression "m h dom mon dow" (required).
+  #     max-runs: Optional positive integer to limit total executions (1 = run once).
+
+  # --- Example 1: New player welcome mail ---
+  welcome-new-players:
+    enabled: false
+    type: FIRST_JOIN
+    message: "&aWelcome to the server!"
+    sender: "Server"
+    expire-days: 7
+    items:
+      - "minecraft:cookie 16"  # Give 16 cookies when claiming the mail.
+    commands:
+      - "title %player% subtitle {\"text\":\"Check /mailbox for a welcome gift!\",\"color\":\"gold\"}"
+    schedule:
+      delay-seconds: 10        # Wait 10 seconds after first join before sending.
+
+  # --- Example 2: Daily reward for everyone at 18:00 server time ---
+  daily-reward:
+    enabled: false
+    type: REPEATING
+    receiver: "all"
+    message: "&eYour daily reward is waiting!"
+    sender: "Server"
+    expire-days: 3
+    items:
+      - "minecraft:diamond 1"
+    commands: []
+    schedule:
+      cron: "0 18 * * *"       # Minute Hour DOM Month DOW -> 18:00 every day.
+      # max-runs omitted -> repeats forever.
+
+  # --- Example 3: Single launch announcement, runs once on Jan 1 at 12:00 ---
+  launch-announcement:
+    enabled: false
+    type: REPEATING
+    receiver: "all"
+    message: "&6Server launch celebration!"
+    sender: "Server"
+    expire-days: 14
+    items:
+      - "minecraft:emerald 3"
+    commands:
+      - "broadcast Server is live!"
+    schedule:
+      cron: "0 12 1 1 *"       # Noon on January 1.
+      max-runs: 1              # Limit to a single execution.
+```
+
+</details>
 
 ## Requirements
 

--- a/src/main/java/com/yusaki/lammailbox/gui/ConfigMailGuiFactory.java
+++ b/src/main/java/com/yusaki/lammailbox/gui/ConfigMailGuiFactory.java
@@ -715,30 +715,11 @@ public class ConfigMailGuiFactory implements MailGuiFactory {
         // Preview item
         int previewSlot = config().getInt(base + ".items.preview.slot", size / 2);
         ItemStack preview = draft.buildPreviewItem(plugin);
-        ItemMeta previewMeta = preview.getItemMeta();
-        if (previewMeta != null) {
-            String previewName = config().getString(base + ".items.preview.name");
-            if (previewName != null) {
-                previewMeta.setDisplayName(plugin.colorize(applyPlaceholders(previewName, placeholders)));
-            }
-            List<String> previewLore = config().getStringList(base + ".items.preview.lore");
-            if (!previewLore.isEmpty()) {
-                previewMeta.setLore(previewLore.stream()
-                        .map(line -> plugin.colorize(applyPlaceholders(line, placeholders)))
-                        .collect(Collectors.toList()));
-            }
-            preview.setItemMeta(previewMeta);
-        }
         inv.setItem(previewSlot, preview);
 
         if (isEnabled(base + ".items.save-button")) {
             ItemStack save = buildEditorStaticButton(base + ".items.save-button", "save");
             inv.setItem(config().getInt(base + ".items.save-button.slot", size - 6), save);
-        }
-
-        if (isEnabled(base + ".items.cancel-button")) {
-            ItemStack cancel = buildEditorStaticButton(base + ".items.cancel-button", "cancel");
-            inv.setItem(config().getInt(base + ".items.cancel-button.slot", size - 4), cancel);
         }
 
         return inv;

--- a/src/main/java/com/yusaki/lammailbox/gui/InventoryClickHandler.java
+++ b/src/main/java/com/yusaki/lammailbox/gui/InventoryClickHandler.java
@@ -373,10 +373,6 @@ public class InventoryClickHandler implements MailInventoryHandler {
                     plugin.openCommandItemCreator(player);
                 }
                 break;
-            case "cancel":
-                plugin.getMailCreationController().cancelCommandItemEdit(session);
-                plugin.openCommandItemsEditor(player);
-                break;
         }
     }
 

--- a/src/main/java/com/yusaki/lammailbox/gui/MailGuiFactory.java
+++ b/src/main/java/com/yusaki/lammailbox/gui/MailGuiFactory.java
@@ -20,4 +20,8 @@ public interface MailGuiFactory {
     Inventory createMailCreation(Player viewer);
 
     Inventory createItemsEditor(Player viewer);
+
+    Inventory createCommandItemsEditor(Player viewer);
+
+    Inventory createCommandItemCreator(Player viewer);
 }

--- a/src/main/java/com/yusaki/lammailbox/mailing/MailingConfigLoader.java
+++ b/src/main/java/com/yusaki/lammailbox/mailing/MailingConfigLoader.java
@@ -1,6 +1,7 @@
 package com.yusaki.lammailbox.mailing;
 
 import com.yusaki.lammailbox.LamMailBox;
+import com.yusaki.lammailbox.model.CommandItem;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.file.YamlConfiguration;
 
@@ -11,6 +12,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
+import java.util.Map;
 
 public final class MailingConfigLoader {
     private final LamMailBox plugin;
@@ -63,6 +65,11 @@ public final class MailingConfigLoader {
                 .expireDays(parsePositiveInt(section, "expire-days"))
                 .itemDirectives(cleanStrings(section.getStringList("items")))
                 .commands(cleanStrings(section.getStringList("commands")));
+
+        List<Map<?, ?>> rawCommandItems = section.getMapList("command-items");
+        if (rawCommandItems != null && !rawCommandItems.isEmpty()) {
+            builder.commandItems(parseCommandItems(rawCommandItems));
+        }
 
         ConfigurationSection schedule = section.getConfigurationSection("schedule");
 
@@ -149,6 +156,26 @@ public final class MailingConfigLoader {
             }
         }
         return cleaned;
+    }
+
+    private List<CommandItem> parseCommandItems(List<Map<?, ?>> rawItems) {
+        List<CommandItem> items = new ArrayList<>();
+        for (Map<?, ?> rawItem : rawItems) {
+            if (rawItem == null) {
+                continue;
+            }
+            Map<String, Object> normalized = new java.util.HashMap<>();
+            for (Map.Entry<?, ?> entry : rawItem.entrySet()) {
+                if (entry.getKey() != null) {
+                    normalized.put(entry.getKey().toString(), entry.getValue());
+                }
+            }
+            CommandItem item = CommandItem.fromMap(normalized);
+            if (item != null) {
+                items.add(item);
+            }
+        }
+        return items;
     }
 
     private Integer parsePositiveInt(ConfigurationSection section, String path) {

--- a/src/main/java/com/yusaki/lammailbox/mailing/MailingScheduler.java
+++ b/src/main/java/com/yusaki/lammailbox/mailing/MailingScheduler.java
@@ -12,6 +12,7 @@ import com.yusaki.lammailbox.mailing.status.MailingStatusRepository;
 import com.yusaki.lammailbox.service.MailDelivery;
 import com.yusaki.lammailbox.service.MailService;
 import com.yusaki.lammailbox.session.MailCreationSession;
+import com.yusaki.lammailbox.model.CommandItem;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
@@ -224,6 +225,7 @@ public final class MailingScheduler {
 
         // Only add actual commands, not converted items
         session.setCommands(new ArrayList<>(definition.commands()));
+        session.setCommandItems(new ArrayList<>(definition.commandItems()));
 
         if (definition.expireDays() != null) {
             long expireAt = System.currentTimeMillis() + definition.expireDays() * 86_400_000L;

--- a/src/main/java/com/yusaki/lammailbox/model/CommandItem.java
+++ b/src/main/java/com/yusaki/lammailbox/model/CommandItem.java
@@ -1,0 +1,248 @@
+package com.yusaki.lammailbox.model;
+
+import com.yusaki.lammailbox.LamMailBox;
+import org.bukkit.Material;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Represents a virtual command item that is rendered in GUIs but never handed to players.
+ */
+public final class CommandItem {
+    private static final String DEFAULT_MATERIAL = "COMMAND_BLOCK";
+
+    private final String materialKey;
+    private final String displayName;
+    private final List<String> lore;
+    private final List<String> commands;
+
+    private CommandItem(Builder builder) {
+        this.materialKey = builder.materialKey;
+        this.displayName = builder.displayName;
+        this.lore = Collections.unmodifiableList(new ArrayList<>(builder.lore));
+        this.commands = Collections.unmodifiableList(new ArrayList<>(builder.commands));
+    }
+
+    public String materialKey() {
+        return materialKey;
+    }
+
+    public String displayName() {
+        return displayName;
+    }
+
+    public List<String> lore() {
+        return lore;
+    }
+
+    public List<String> commands() {
+        return commands;
+    }
+
+    public ItemStack toPreviewItem(LamMailBox plugin) {
+        Material material = resolveMaterial(materialKey);
+        if (material == null) {
+            material = Material.COMMAND_BLOCK;
+        }
+
+        ItemStack stack = new ItemStack(material);
+        ItemMeta meta = stack.getItemMeta();
+        if (meta != null) {
+            String name = Objects.requireNonNullElse(displayName, "&6Command Item");
+            meta.setDisplayName(plugin.colorize(name));
+
+            List<String> coloredLore = lore.isEmpty()
+                    ? Collections.singletonList(plugin.colorize("&7Executes console commands"))
+                    : lore.stream().map(plugin::colorize).toList();
+            meta.setLore(coloredLore);
+            stack.setItemMeta(meta);
+        }
+        return stack;
+    }
+
+    public Map<String, Object> toMap() {
+        Map<String, Object> map = new HashMap<>();
+        map.put("material", materialKey);
+        map.put("name", displayName);
+        map.put("lore", new ArrayList<>(lore));
+        map.put("commands", new ArrayList<>(commands));
+        return map;
+    }
+
+    public static CommandItem fromMap(Map<String, Object> map) {
+        if (map == null) {
+            return null;
+        }
+        Builder builder = new Builder();
+        Object material = map.get("material");
+        if (material instanceof String materialStr && !materialStr.isBlank()) {
+            builder.material(materialStr.trim());
+        }
+
+        Object name = map.get("name");
+        if (name instanceof String nameStr) {
+            builder.displayName(nameStr);
+        }
+
+        Object loreRaw = map.get("lore");
+        if (loreRaw instanceof List<?> list) {
+            for (Object entry : list) {
+                if (entry != null) {
+                    builder.addLoreLine(entry.toString());
+                }
+            }
+        }
+
+        Object commandsRaw = map.get("commands");
+        if (commandsRaw instanceof List<?> list) {
+            for (Object entry : list) {
+                if (entry != null) {
+                    builder.addCommand(entry.toString());
+                }
+            }
+        }
+
+        return builder.build();
+    }
+
+    public static CommandItem legacyFromCommand(String command) {
+        Builder builder = new Builder();
+        builder.addCommand(command);
+        builder.displayName("&6Console Command");
+        builder.addLoreLine("&7Runs:&f " + command);
+        return builder.build();
+    }
+
+    public Builder toBuilder() {
+        Builder builder = new Builder();
+        builder.material(this.materialKey);
+        builder.displayName(this.displayName);
+        builder.lore.addAll(this.lore);
+        builder.commands.addAll(this.commands);
+        return builder;
+    }
+
+    private static Material resolveMaterial(String materialKey) {
+        if (materialKey == null || materialKey.isBlank()) {
+            return Material.matchMaterial(DEFAULT_MATERIAL);
+        }
+        Material match = Material.matchMaterial(materialKey);
+        if (match != null) {
+            return match;
+        }
+        try {
+            return Material.valueOf(materialKey.trim().toUpperCase(Locale.ROOT));
+        } catch (IllegalArgumentException ignored) {
+            return Material.matchMaterial(DEFAULT_MATERIAL);
+        }
+    }
+
+    public static final class Builder {
+        private String materialKey = DEFAULT_MATERIAL;
+        private String displayName = "&6Command Item";
+        private final List<String> lore = new ArrayList<>();
+        private final List<String> commands = new ArrayList<>();
+
+        public Builder material(String materialKey) {
+            if (materialKey != null && !materialKey.isBlank()) {
+                this.materialKey = materialKey.trim().toUpperCase(Locale.ROOT);
+            }
+            return this;
+        }
+
+        public Builder displayName(String displayName) {
+            if (displayName != null) {
+                this.displayName = displayName;
+            }
+            return this;
+        }
+
+        public Builder clearLore() {
+            this.lore.clear();
+            return this;
+        }
+
+        public Builder addLoreLine(String line) {
+            if (line != null) {
+                this.lore.add(line);
+            }
+            return this;
+        }
+
+        public boolean removeLastLoreLine() {
+            if (this.lore.isEmpty()) {
+                return false;
+            }
+            this.lore.remove(this.lore.size() - 1);
+            return true;
+        }
+
+        public Builder setLore(List<String> lines) {
+            this.lore.clear();
+            if (lines != null) {
+                lines.forEach(this::addLoreLine);
+            }
+            return this;
+        }
+
+        public Builder clearCommands() {
+            this.commands.clear();
+            return this;
+        }
+
+        public Builder addCommand(String command) {
+            if (command != null && !command.isBlank()) {
+                this.commands.add(command.trim());
+            }
+            return this;
+        }
+
+        public boolean removeLastCommand() {
+            if (this.commands.isEmpty()) {
+                return false;
+            }
+            this.commands.remove(this.commands.size() - 1);
+            return true;
+        }
+
+        public Builder setCommands(List<String> commands) {
+            this.commands.clear();
+            if (commands != null) {
+                commands.forEach(this::addCommand);
+            }
+            return this;
+        }
+
+        public String materialKey() {
+            return materialKey;
+        }
+
+        public List<String> lore() {
+            return lore;
+        }
+
+        public List<String> commands() {
+            return commands;
+        }
+
+        public String displayName() {
+            return displayName;
+        }
+
+        public CommandItem build() {
+            return new CommandItem(this);
+        }
+
+        public ItemStack buildPreviewItem(LamMailBox plugin) {
+            return build().toPreviewItem(plugin);
+        }
+    }
+}

--- a/src/main/java/com/yusaki/lammailbox/model/CommandItem.java
+++ b/src/main/java/com/yusaki/lammailbox/model/CommandItem.java
@@ -56,13 +56,16 @@ public final class CommandItem {
         ItemStack stack = new ItemStack(material);
         ItemMeta meta = stack.getItemMeta();
         if (meta != null) {
-            String name = Objects.requireNonNullElse(displayName, "&6Command Item");
+            String name = displayName == null || displayName.isBlank()
+                    ? "&6Console Action"
+                    : displayName;
             meta.setDisplayName(plugin.colorize(name));
 
-            List<String> coloredLore = lore.isEmpty()
-                    ? Collections.singletonList(plugin.colorize("&7Executes console commands"))
-                    : lore.stream().map(plugin::colorize).toList();
-            meta.setLore(coloredLore);
+            List<String> displayLore = lore.isEmpty() ? Collections.emptyList() : lore;
+            List<String> loreLines = displayLore.stream()
+                    .map(plugin::colorize)
+                    .toList();
+            meta.setLore(loreLines);
             stack.setItemMeta(meta);
         }
         return stack;

--- a/src/main/java/com/yusaki/lammailbox/session/MailCreationSession.java
+++ b/src/main/java/com/yusaki/lammailbox/session/MailCreationSession.java
@@ -1,9 +1,14 @@
 package com.yusaki.lammailbox.session;
 
+import com.yusaki.lammailbox.model.CommandItem;
 import org.bukkit.inventory.ItemStack;
 
 import java.util.ArrayList;
 import java.util.List;
+
+/**
+ * Mutable state while a player is composing a mail.
+ */
 
 /**
  * Mutable state while a player is composing a mail.
@@ -17,6 +22,9 @@ public class MailCreationSession {
     private ItemStack displayCommandBlock;
     private Long scheduleDate;
     private Long expireDate;
+    private List<CommandItem> commandItems = new ArrayList<>();
+    private CommandItem.Builder commandItemDraft;
+    private Integer commandItemEditIndex;
 
     public String getReceiver() {
         return receiver;
@@ -55,7 +63,13 @@ public class MailCreationSession {
     }
 
     public void setCommands(List<String> commands) {
-        this.commands = commands;
+        this.commands = commands != null ? new ArrayList<>(commands) : new ArrayList<>();
+        if ((this.commandItems == null || this.commandItems.isEmpty()) && this.commands != null && !this.commands.isEmpty()) {
+            this.commandItems = new ArrayList<>();
+            for (String command : this.commands) {
+                this.commandItems.add(CommandItem.legacyFromCommand(command));
+            }
+        }
     }
 
     public ItemStack getDisplayCommandBlock() {
@@ -84,5 +98,33 @@ public class MailCreationSession {
 
     public boolean isComplete() {
         return receiver != null && message != null;
+    }
+
+    public List<CommandItem> getCommandItems() {
+        return commandItems;
+    }
+
+    public void setCommandItems(List<CommandItem> commandItems) {
+        this.commandItems = commandItems != null ? new ArrayList<>(commandItems) : new ArrayList<>();
+        List<String> flattened = this.commandItems.stream()
+                .flatMap(item -> item.commands().stream())
+                .collect(java.util.stream.Collectors.toList());
+        this.commands = flattened;
+    }
+
+    public CommandItem.Builder getCommandItemDraft() {
+        return commandItemDraft;
+    }
+
+    public void setCommandItemDraft(CommandItem.Builder commandItemDraft) {
+        this.commandItemDraft = commandItemDraft;
+    }
+
+    public Integer getCommandItemEditIndex() {
+        return commandItemEditIndex;
+    }
+
+    public void setCommandItemEditIndex(Integer commandItemEditIndex) {
+        this.commandItemEditIndex = commandItemEditIndex;
     }
 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,4 +1,4 @@
-version: 1.3
+version: 1.4
 
 settings:
   max-mails-per-player: 54
@@ -147,14 +147,12 @@ gui:
         enabled: true
         slots: [10,11,12,13,14,15,16,19,20,21,22,23,24,25,28,29,30,31,32,33,34]
 
-      command-item:
+      command-legacy:
         enabled: true
         material: COMMAND_BLOCK
-        name: '&6Console Action #%index%'
+        name: '&6Console Action'
         lore:
-          - '&7Command: &f%summary%'
           - '&7Runs a server command when claimed.'
-          - '&7Total commands: &f%total%'
 
       delete-button:
         enabled: true
@@ -261,16 +259,13 @@ gui:
         enabled: true
         material: BLACK_STAINED_GLASS_PANE
         name: ' '
-        slots: [0,1,2,3,4,5,6,7,8,9,17,18,26]
+        slots: [0,1,2,3,4,5,6,7,8,9,17,18,19,20,21,22,23,26]
     items:
       command-item:
         enabled: true
         slots: [10,11,12,13,14,15,16]
-        name: '&6Action #%index%'
+        command-header: '&7Commands:'
         lore:
-          - '&7Material: &f%material%'
-          - '&7Name: &f%name%'
-          - '&7Commands: &f%commands%'
           - '&7Left-click to edit'
           - '&7Right-click to delete'
       add-button:
@@ -296,7 +291,7 @@ gui:
         enabled: true
         material: BLACK_STAINED_GLASS_PANE
         name: ' '
-        slots: [0,1,2,3,4,5,6,7,8,9,17,18,26]
+        slots: [0,1,2,3,4,5,6,7,8,9,17,18,19,20,21,22,23,24,25]
     items:
       material-selector:
         enabled: true
@@ -369,10 +364,10 @@ gui:
         enabled: true
         slots: [10,11,12,13,14,15,16,19,20,21,22,23,24,25,28,29,30,31,32,33,34]
 
-      command-item:
+      command-legacy:
         enabled: true
         material: COMMAND_BLOCK
-        name: '&6Command'
+        name: '&6Console Action'
         lore:
           - '&7Executes when claimed'
 

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -216,12 +216,10 @@ gui:
       command-block:
         enabled: true
         material: COMMAND_BLOCK
-        name: "&6ᴄᴏᴍᴍᴀɴᴅs"
+        name: "&6ᴄᴏᴍᴍᴀɴᴅ ɪᴛᴇᴍs"
         lore:
-          - "&7ʟᴇғᴛ-ᴄʟɪᴄᴋ ᴛᴏ ᴀᴅᴅ"
-          - "&7ʀɪɢʜᴛ-ᴄʟɪᴄᴋ ᴛᴏ ʀᴇᴍᴏᴠᴇ"
-        commands-prefix: "&bCommands:"
-        command-format: "&7⟫ /%command%"
+          - "&7ᴄʟɪᴄᴋ ᴛᴏ ᴍᴀɴᴀɢᴇ ᴀᴄᴛɪᴏɴs"
+          - "&7Configured: &f%count%"
         slot: 15
 
       schedule-clock:
@@ -254,6 +252,102 @@ gui:
         lore:
           - '&7ᴄʟɪᴄᴋ ᴛᴏ sᴀᴠᴇ'
         slot: 26
+
+  command-items-editor:
+    title: '&8ᴄᴏᴍᴍᴀɴᴅ ɪᴛᴇᴍs'
+    size: 27
+    decoration:
+      border:
+        enabled: true
+        material: BLACK_STAINED_GLASS_PANE
+        name: ' '
+        slots: [0,1,2,3,4,5,6,7,8,9,17,18,26]
+    items:
+      command-item:
+        enabled: true
+        slots: [10,11,12,13,14,15,16]
+        name: '&6Action #%index%'
+        lore:
+          - '&7Material: &f%material%'
+          - '&7Name: &f%name%'
+          - '&7Commands: &f%commands%'
+          - '&7Left-click to edit'
+          - '&7Right-click to delete'
+      add-button:
+        enabled: true
+        material: LIME_STAINED_GLASS_PANE
+        name: '&a+ Add Command Item'
+        lore:
+          - '&7Create a new command action'
+        slot: 24
+      back-button:
+        enabled: true
+        material: ARROW
+        name: '&cBack to Mail Creation'
+        lore:
+          - '&7Return to compose menu'
+        slot: 25
+
+  command-item-creator:
+    title: '&8ᴄᴏᴍᴍᴀɴᴅ ɪᴛᴇᴍ ᴇᴅɪᴛᴏʀ'
+    size: 27
+    decoration:
+      border:
+        enabled: true
+        material: BLACK_STAINED_GLASS_PANE
+        name: ' '
+        slots: [0,1,2,3,4,5,6,7,8,9,17,18,26]
+    items:
+      material-selector:
+        enabled: true
+        material: IRON_INGOT
+        name: '&eSelect Material (&f%material%&e)'
+        lore:
+          - '&7Click to enter a material name'
+        slot: 10
+      name-editor:
+        enabled: true
+        material: NAME_TAG
+        name: '&bDisplay Name'
+        lore:
+          - '&7Current: &f%name%'
+          - '&7Click to edit via chat'
+        slot: 12
+      lore-editor:
+        enabled: true
+        material: WRITABLE_BOOK
+        name: '&dLore (&f%lore_count% &dlɪɴᴇs)'
+        lore:
+          - '&7Left-click to add line'
+          - '&7Right-click to remove last'
+        slot: 13
+      commands-editor:
+        enabled: true
+        material: COMMAND_BLOCK
+        name: '&6Commands (&f%command_count%&6)'
+        lore:
+          - '&7Left-click to add command'
+          - '&7Right-click to remove last'
+        slot: 14
+      preview:
+        name: '&aPreview'
+        lore:
+          - '&7Shows the final appearance'
+        slot: 16
+      save-button:
+        enabled: true
+        material: LIME_CONCRETE
+        name: '&aSave Command Item'
+        lore:
+          - '&7Store this command action'
+        slot: 24
+      cancel-button:
+        enabled: true
+        material: RED_CONCRETE
+        name: '&cCancel'
+        lore:
+          - '&7Discard changes'
+        slot: 25
 
   mail-view:
     title: "&8ᴠɪᴇᴡɪɴɢ ᴍᴀɪʟ"
@@ -330,6 +424,16 @@ gui:
 
 messages:
   prefix: '&8[&6✉ LamMailBox&8] '
+  mailings:
+    header: '&6✉ Scheduled Mailings'
+    empty: '&7No scheduled mailings configured.'
+    entry-repeating: '&e• &f%id% &8| %status% &8| &7Schedule: &f%schedule% &8| &7Next: &f%next% &8| &7Last: &f%last%%runs%%completed%'
+    entry-first-join: '&e• &f%id% &8| %status% &8| &7Trigger: &fOn first join%completed%'
+    runs: ' &8| &7Runs: &f%current%&7/&f%max%'
+    completed: ' &8| &a✓ Completed'
+    value-missing: '&7—'
+    status-enabled: '&aEnabled'
+    status-disabled: '&cDisabled'
   mailbox-full: '&c✖ This mailbox is full! Maximum capacity reached.'
   enter-receiver: '&e✎ Who would you like to send this mail to?'
   enter-message: '&e✎ Write your message below:'
@@ -341,6 +445,10 @@ messages:
   inventory-space-needed: '&c⚠ You need %amount% free inventory slots to claim these items!'
   items-claimed: '&a✔ Items claimed and added to your inventory!'
   enter-command: '&a⌘ Enter your command below (without the /)'
+  enter-command-item-material: '&eEnter item material (e.g., DIAMOND, EMERALD):'
+  enter-command-item-name: '&eEnter item display name (color codes supported):'
+  enter-command-item-lore: '&eEnter lore line. Right-click the lore button to remove the last entry.'
+  enter-command-item-command: '&eEnter command (without /). Right-click the command button to remove the last entry.'
   incomplete-mail: '&c⚠ Cannot send mail - some details are missing!'
   current-receiver: '&a✉ Sending to: &f%receiver%'
   current-message: '&a✎ Your message:'
@@ -358,6 +466,24 @@ messages:
   invalid-date-format: "&c✖ Invalid date! Use format: YYYY:MM:DD:HH:mm"
   schedule-set: "&a✔ Delivery scheduled for: %date%"
   expire-set: "&a✔ Mail will expire on: %date%"
+  invalid-material: '&c✖ Invalid material! Use valid Bukkit material names.'
+  command-item-material-set: '&a✔ Command item material updated.'
+  command-item-name-set: '&a✔ Display name updated.'
+  command-item-name-failed: '&c✖ Could not update display name.'
+  command-item-lore-finished: '&a✔ Lore editing complete.'
+  command-item-lore-cleared: '&a✔ Lore cleared.'
+  command-item-lore-added: '&a✔ Added lore line.'
+  command-item-lore-failed: '&c✖ Could not update lore.'
+  command-item-lore-removed: '&a✔ Removed last lore line.'
+  command-item-lore-empty: '&c✖ No lore lines to remove.'
+  command-item-command-finished: '&a✔ Command editing complete.'
+  command-item-command-removed: '&a✔ Removed last command.'
+  command-item-command-empty: '&c✖ No commands to remove.'
+  command-item-command-added: '&a✔ Added command.'
+  command-item-command-failed: '&c✖ Could not update commands.'
+  command-item-no-draft: '&c✖ Nothing to save.'
+  command-item-requires-command: '&c✖ Add at least one command before saving.'
+  command-item-saved: '&a✔ Command item saved!'
   self-mail: '&c✖ You cannot send mail to yourself!'
   reload-success: '&a✔ Configuration reloaded successfully!'
   no-items-in-mail: '&a✔ Mail marked as read.'
@@ -401,6 +527,18 @@ titles:
     command:
       title: "&6⌘ Add Command"
       subtitle: "&eType command without /"
+    command-item-material:
+      title: "&6⌘ Command Item Material"
+      subtitle: "&eEnter a Bukkit material (e.g., DIAMOND)"
+    command-item-name:
+      title: "&6⌘ Command Item Name"
+      subtitle: "&eProvide the display name"
+    command-item-lore:
+      title: "&6⌘ Command Item Lore"
+      subtitle: "&eEnter lore text"
+    command-item-command:
+      title: "&6⌘ Command Item Action"
+      subtitle: "&eEnter console command (no /)"
     schedule:
       title: "&6⏰ Schedule Delivery"
       subtitle: "&eFormat: YYYY:MM:DD:HH:mm"

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -330,9 +330,6 @@ gui:
           - '&7Right-click to remove last'
         slot: 14
       preview:
-        name: '&aPreview'
-        lore:
-          - '&7Shows the final appearance'
         slot: 16
       save-button:
         enabled: true
@@ -340,14 +337,7 @@ gui:
         name: '&aSave Command Item'
         lore:
           - '&7Store this command action'
-        slot: 24
-      cancel-button:
-        enabled: true
-        material: RED_CONCRETE
-        name: '&cCancel'
-        lore:
-          - '&7Discard changes'
-        slot: 25
+        slot: 26
 
   mail-view:
     title: "&8ᴠɪᴇᴡɪɴɢ ᴍᴀɪʟ"

--- a/src/main/resources/mailings.yml
+++ b/src/main/resources/mailings.yml
@@ -11,6 +11,8 @@ mailings:
   # expire-days: Optional integer; how many days until the mail auto-expires (null = config default).
   # items: List of item directives converted directly into ItemStacks (supports namespace ids).
   # commands: Console commands executed when the mail is claimed (supports %player% placeholder).
+  # command-items: Preferred way to define console actions; each entry mirrors the GUI command bundles
+  #                (material, display name, lore, commands) and is shown in the mail view.
   # schedule:
   #   For FIRST_JOIN:
   #     delay-minutes / delay-seconds (optional) -> wait before delivering after first join.

--- a/src/main/resources/mailings.yml
+++ b/src/main/resources/mailings.yml
@@ -62,3 +62,24 @@ mailings:
     schedule:
       cron: "0 12 1 1 *"       # Noon on January 1.
       max-runs: 1              # Limit to a single execution.
+
+  # --- Example 4: Rich command item with custom display ---
+  welcome-bundle:
+    enabled: false
+    type: REPEATING
+    receiver: "all"
+    message: "&aEnjoy your welcome bundle!"
+    sender: "Console"
+    command-items:
+      - material: CHEST
+        name: "&6Starter Bundle"
+        lore:
+          - "&7Runs multiple console actions"
+          - "&7and shows a custom icon"
+        commands:
+          - "give %player% minecraft:bread 8"
+          - "give %player% minecraft:stone_sword 1"
+          - "xp add %player% 5 levels"
+    schedule:
+      cron: "0 9 * * *"        # 09:00 every day.
+      max-runs: 1


### PR DESCRIPTION
### Summary

Adds complete support for creating, editing, and displaying rich "command items" via GUI when composing mail or configuring scheduled mailings.

### Details

- Introduces a CommandItem abstraction: allows bundling commands with custom display name, material, and lore.
- Extends YAML config (mailings.yml) and GUI to fully support and document `command-items`, providing more customizable mail-triggered actions.
- Implements GUI editors for creating, editing, and managing command items, replacing legacy single-command logic.
- Updates mail storage, loading/saving, and repository code to persist full command item data (name, lore, material, multiple commands).
- Refactors codebase to distinguish between legacy and rich command items and ensures backward compatibility.
- Streamlines GUI and user input flow for a more intuitive experience, removing obsolete/cancel actions and preview customizations.
- Updates documentation and configuration comments to reflect new command item features.

### Motivation

Enables admins to design mail-triggered actions that better fit server needs, presentable to players as clickable bundles with rich information, improving flexibility and user experience when automating rewards and events.