### PR TITLE
Unifies message handling and dynamic command aliases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,13 +42,14 @@ jobs:
     - name: Build and install YskLib
       run: |
         cd YskLib
+        YSKLIB_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
         mvn clean package -DskipTests -Dbuild.number.formatted=-${{ steps.ysklib-commit.outputs.sha }}
         JAR_PATH=$(ls target/YskLib-1.*.jar | head -n 1)
         mvn install:install-file \
           -Dfile="$JAR_PATH" \
           -DgroupId=org.yusaki \
           -DartifactId=lib \
-          -Dversion=1.6.4 \
+          -Dversion=$YSKLIB_VERSION \
           -Dpackaging=jar \
           -DgeneratePom=true
         cd ..

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ MODRINTH.md
 docs/
 
 AGENTS.md
+
+.factory/

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Need examples or deeper guidance? Check the wiki:
 
 * Paper or Folia 1.20+
 * Java 21 runtime
-* [YskLib](https://github.com/YusakiDev/YskLib/releases) 1.6.4 or above
+* [YskLib](https://github.com/YusakiDev/YskLib/releases) 1.6.5 or above
 
 ## Support
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Need examples or deeper guidance? Check the wiki:
 
 * Paper or Folia 1.20+
 * Java 21 runtime
-* [YskLib](https://github.com/YusakiDev/YskLib/releases) 1.6.6 or above
+* [YskLib](https://github.com/YusakiDev/YskLib/releases) 1.6.7 or above
 
 ## Support
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 LamMailBox lets admins deliver items and rich-text messages to players who don’t need to be online. It’s a lightweight mailbox system for Paper/Folia 1.20+ that works from commands or plugin triggers.
 
-**Latest release:** v1.5.2
+**Latest release:** v1.5.3
 
 ## Key Features
 
@@ -83,7 +83,7 @@ Need examples or deeper guidance? Check the wiki:
 
 * Paper or Folia 1.20+
 * Java 21 runtime
-* [YskLib](https://github.com/YusakiDev/YskLib/releases) 1.6.5 or above
+* [YskLib](https://github.com/YusakiDev/YskLib/releases) 1.6.6 or above
 
 ## Support
 

--- a/pom.xml
+++ b/pom.xml
@@ -113,7 +113,7 @@
         <dependency>
             <groupId>org.yusaki</groupId>
             <artifactId>lib</artifactId>
-            <version>1.6.6</version>
+            <version>1.6.7</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.yusaki</groupId>
     <artifactId>LamMailBox</artifactId>
-    <version>1.5.2</version>
+    <version>1.5.3</version>
     <packaging>jar</packaging>
 
     <name>LamMailBox</name>

--- a/pom.xml
+++ b/pom.xml
@@ -113,7 +113,7 @@
         <dependency>
             <groupId>org.yusaki</groupId>
             <artifactId>lib</artifactId>
-            <version>1.6.5</version>
+            <version>1.6.6</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -113,7 +113,7 @@
         <dependency>
             <groupId>org.yusaki</groupId>
             <artifactId>lib</artifactId>
-            <version>1.6.4</version>
+            <version>1.6.5</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -88,10 +88,6 @@
             <url>https://jitpack.io</url>
         </repository>
         <repository>
-            <id>frep-repo</id>
-            <url>https://repo.frep.me/repository/maven-public/</url>
-        </repository>
-        <repository>
             <id>tcoded-releases</id>
             <url>https://repo.tcoded.com/releases</url>
         </repository>

--- a/src/main/java/com/yusaki/lammailbox/LamMailBox.java
+++ b/src/main/java/com/yusaki/lammailbox/LamMailBox.java
@@ -105,7 +105,7 @@ public class LamMailBox extends JavaPlugin implements Listener {
         // Initialize YskLib MessageManager
         yskLib = (YskLib) getServer().getPluginManager().getPlugin("YskLib");
         if (yskLib == null) {
-            getLogger().severe("YskLib not found! Please install YskLib 1.6.5 or above.");
+            getLogger().severe("YskLib not found! Please install YskLib 1.6.7 or above.");
             getServer().getPluginManager().disablePlugin(this);
             return;
         }

--- a/src/main/java/com/yusaki/lammailbox/LamMailBox.java
+++ b/src/main/java/com/yusaki/lammailbox/LamMailBox.java
@@ -9,6 +9,8 @@ import com.cronutils.parser.CronParser;
 import com.tcoded.folialib.FoliaLib;
 import net.md_5.bungee.api.chat.ClickEvent;
 import net.md_5.bungee.api.chat.TextComponent;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 import org.bukkit.Bukkit;
 import org.bukkit.Sound;
 import org.bukkit.command.PluginCommand;
@@ -81,6 +83,9 @@ public class LamMailBox extends JavaPlugin implements Listener {
     private boolean mailingAutoCleanup;
     private CronParser cronParser;
     private CronDescriptor cronDescriptor;
+    private final LegacyComponentSerializer legacySerializer = LegacyComponentSerializer.legacyAmpersand();
+    private Component cachedPrefixComponent;
+    private String cachedPrefixLegacy;
 
     @Override
     public void onEnable() {
@@ -106,6 +111,7 @@ public class LamMailBox extends JavaPlugin implements Listener {
         }
         yskLib.loadMessages(this);
         messageManager = yskLib.getMessageManager();
+        invalidatePrefixCache();
 
         StorageSettings storageSettings = StorageSettings.load(this);
         mailRepository = createRepository(storageSettings);
@@ -142,7 +148,7 @@ public class LamMailBox extends JavaPlugin implements Listener {
 
         getCommand("lmbreload").setExecutor((sender, cmd, label, args) -> {
             if (!sender.hasPermission(config.getString("settings.permissions.reload"))) {
-                sender.sendMessage(colorize(config.getString("messages.no-permission")));
+                sendPrefixedMessage(sender, "messages.no-permission");
                 return true;
             }
 
@@ -150,16 +156,18 @@ public class LamMailBox extends JavaPlugin implements Listener {
             configUpdater.updateConfigs();
             reloadConfig();
             config = getConfig();
+            yskLib.loadMessages(this);
+            messageManager = yskLib.getMessageManager();
+            invalidatePrefixCache();
             mailingAutoCleanup = config.getBoolean("mailings.auto-cleanup", true);
             updateCommandAliases();
             reloadMailings();
-            sender.sendMessage(colorize(config.getString("messages.reload-success")));
+            sendPrefixedMessage(sender, "messages.reload-success");
 
             List<MailingDefinition> definitions = getMailingDefinitions();
             if (!definitions.isEmpty()) {
                 long activeCount = definitions.stream().filter(MailingDefinition::enabled).count();
-                String summary = config.getString("messages.prefix") + "&7Mailings active: &a" + activeCount + "&7/&f" + definitions.size();
-                sender.sendMessage(colorize(summary));
+                sendPrefixedRaw(sender, "&7Mailings active: &a" + activeCount + "&7/&f" + definitions.size());
 
                 if (activeCount > 0) {
                     int previewLimit = 5;
@@ -171,15 +179,15 @@ public class LamMailBox extends JavaPlugin implements Listener {
                             ? activeIds.subList(0, previewLimit)
                             : activeIds;
                     String idsLine = String.join("&f, ", preview);
-                    String detail = config.getString("messages.prefix") + "&7Active IDs: &f" + idsLine;
+                    String detail = "&7Active IDs: &f" + idsLine;
                     if (activeIds.size() > previewLimit) {
                         detail += " &7(+" + (activeIds.size() - previewLimit) + " more)";
                     }
-                    sender.sendMessage(colorize(detail));
+                    sendPrefixedRaw(sender, detail);
                 }
             } else {
                 String emptyMessage = getMailingsMessage("empty", "&7No mailings configured.");
-                sender.sendMessage(colorize(config.getString("messages.prefix") + emptyMessage));
+                sendPrefixedRaw(sender, emptyMessage);
             }
             return true;
         });
@@ -225,7 +233,7 @@ public class LamMailBox extends JavaPlugin implements Listener {
 
     public void openMainGUI(Player player) {
         if (!player.hasPermission(config.getString("settings.permissions.open"))) {
-            player.sendMessage(colorize(config.getString("messages.no-permission")));
+            sendPrefixedMessage(player, "messages.no-permission");
             return;
         }
         player.openInventory(mailGuiFactory.createMailbox(player));
@@ -233,8 +241,7 @@ public class LamMailBox extends JavaPlugin implements Listener {
 
     public void openMailboxAsPlayer(Player admin, Player targetPlayer) {
         if (!admin.hasPermission(config.getString("settings.permissions.view-as"))) {
-            admin.sendMessage(colorize(config.getString("messages.prefix") +
-                    config.getString("messages.no-permission")));
+            sendPrefixedMessage(admin, "messages.no-permission");
             return;
         }
         viewingAsPlayer.put(admin.getUniqueId(), targetPlayer.getName());
@@ -243,7 +250,7 @@ public class LamMailBox extends JavaPlugin implements Listener {
 
     public void openSentMailGUI(Player player) {
         if (!player.hasPermission(config.getString("settings.permissions.open"))) {
-            player.sendMessage(colorize(config.getString("messages.no-permission")));
+            sendPrefixedMessage(player, "messages.no-permission");
             return;
         }
         player.openInventory(mailGuiFactory.createSentMailbox(player));
@@ -256,7 +263,7 @@ public class LamMailBox extends JavaPlugin implements Listener {
     public void handleSentMailDelete(Player player, String mailId) {
         // Check if player can delete this mail (only admins with delete permission)
         if (!player.hasPermission(config.getString("settings.permissions.delete"))) {
-            player.sendMessage(colorize(config.getString("messages.prefix") + config.getString("messages.no-permission")));
+            sendPrefixedMessage(player, "messages.no-permission");
             return;
         }
 
@@ -268,17 +275,17 @@ public class LamMailBox extends JavaPlugin implements Listener {
             
             player.closeInventory();
             openSentMailGUI(player);
-            player.sendMessage(colorize(config.getString("messages.prefix") + config.getString("messages.mail-deleted")));
+            sendPrefixedMessage(player, "messages.mail-deleted");
         } else {
             // First click - ask for confirmation
             deleteConfirmations.put(player.getUniqueId(), mailId);
-            player.sendMessage(colorize(config.getString("messages.prefix") + config.getString("messages.delete-confirmation")));
+            sendPrefixedMessage(player, "messages.delete-confirmation");
         }
     }
 
     public void openCreateMailGUI(Player player) {
         if (!player.hasPermission(config.getString("settings.permissions.compose"))) {
-            player.sendMessage(colorize(config.getString("messages.prefix") + config.getString("messages.no-permission")));
+            sendPrefixedMessage(player, "messages.no-permission");
             return;
         }
         player.openInventory(mailGuiFactory.createMailCreation(player));
@@ -291,8 +298,7 @@ public class LamMailBox extends JavaPlugin implements Listener {
 
     public void openCommandItemsEditor(Player player) {
         if (!player.hasPermission(config.getString("settings.admin-permission"))) {
-            player.sendMessage(colorize(config.getString("messages.prefix") +
-                    config.getString("messages.no-permission")));
+            sendPrefixedMessage(player, "messages.no-permission");
             return;
         }
         inMailCreation.put(player.getUniqueId(), true);
@@ -301,8 +307,7 @@ public class LamMailBox extends JavaPlugin implements Listener {
 
     public void openCommandItemCreator(Player player) {
         if (!player.hasPermission(config.getString("settings.admin-permission"))) {
-            player.sendMessage(colorize(config.getString("messages.prefix") +
-                    config.getString("messages.no-permission")));
+            sendPrefixedMessage(player, "messages.no-permission");
             return;
         }
         inMailCreation.put(player.getUniqueId(), true);
@@ -486,8 +491,7 @@ public class LamMailBox extends JavaPlugin implements Listener {
     public void handleMailSend(Player sender) {
         MailCreationSession session = mailSessions.get(sender.getUniqueId());
         if (session == null || !session.isComplete()) {
-            sender.sendMessage(colorize(config.getString("messages.prefix") +
-                    config.getString("messages.incomplete-mail")));
+            sendPrefixedMessage(sender, "messages.incomplete-mail");
             return;
         }
 
@@ -497,8 +501,7 @@ public class LamMailBox extends JavaPlugin implements Listener {
         try {
             delivery = mailService.sendMail(sender, session);
         } catch (IllegalArgumentException ex) {
-            sender.sendMessage(colorize(config.getString("messages.prefix") +
-                    config.getString("messages.incomplete-mail")));
+            sendPrefixedMessage(sender, "messages.incomplete-mail");
             return;
         }
 
@@ -511,22 +514,73 @@ public class LamMailBox extends JavaPlugin implements Listener {
 
         Long scheduleDate = session.getScheduleDate();
         if (scheduleDate != null && scheduleDate > System.currentTimeMillis()) {
-            sender.sendMessage(colorize(config.getString("messages.prefix") +
-                    applyPlaceholderVariants(config.getString("messages.schedule-set"),
-                            "date",
-                            new Date(scheduleDate).toString())));
+            sendPrefixedMessage(sender, "messages.schedule-set",
+                    placeholders("date", new Date(scheduleDate).toString()));
         } else {
-            sender.sendMessage(colorize(config.getString("messages.prefix") +
-                    config.getString("messages.mail-sent")));
+            sendPrefixedMessage(sender, "messages.mail-sent");
         }
     }
 
-    /**
-     * @deprecated Use getMessage() with MessageManager instead
-     */
-    @Deprecated
-    public String colorize(String text) {
-        return text.replace("&", "§");
+    public MessageManager getMessageManager() {
+        return messageManager;
+    }
+
+    public void invalidatePrefixCache() {
+        cachedPrefixComponent = null;
+        cachedPrefixLegacy = null;
+    }
+
+    public Component deserializeLegacy(String text) {
+        return legacySerializer.deserialize(text == null ? "" : text);
+    }
+
+    public String legacy(String text) {
+        if (text == null || text.isEmpty()) {
+            return "";
+        }
+        return legacySerializer.serialize(deserializeLegacy(text));
+    }
+
+    public Component getPrefixComponent() {
+        if (cachedPrefixComponent == null) {
+            cachedPrefixComponent = deserializeLegacy(messageManager.getPrefix(this));
+        }
+        return cachedPrefixComponent;
+    }
+
+    public String getPrefixLegacy() {
+        if (cachedPrefixLegacy == null) {
+            cachedPrefixLegacy = legacy(messageManager.getPrefix(this));
+        }
+        return cachedPrefixLegacy;
+    }
+
+    public Component prefixed(Component body) {
+        return getPrefixComponent().append(body == null ? Component.empty() : body);
+    }
+
+    public String prefixedLegacy(String body) {
+        Component component = body == null ? Component.empty() : deserializeLegacy(body);
+        return legacySerializer.serialize(prefixed(component));
+    }
+
+    public void sendPrefixedMessage(org.bukkit.command.CommandSender sender, String key) {
+        messageManager.sendPrefixedMessage(this, sender, key);
+    }
+
+    public void sendPrefixedMessage(org.bukkit.command.CommandSender sender, String key, Map<String, String> placeholders) {
+        messageManager.sendPrefixedMessage(this, sender, key, placeholders);
+    }
+
+    public void sendPrefixedMessageList(org.bukkit.command.CommandSender sender, String key) {
+        messageManager.sendPrefixedMessageList(this, sender, key);
+    }
+
+    public void sendPrefixedRaw(org.bukkit.command.CommandSender sender, String message) {
+        if (message == null || message.isEmpty()) {
+            return;
+        }
+        sender.sendMessage(prefixedLegacy(message));
     }
 
     public String applyPlaceholderVariants(String template, String key, String value) {
@@ -641,7 +695,7 @@ public class LamMailBox extends JavaPlugin implements Listener {
                     "sender",
                     sender);
 
-            TextComponent message = new TextComponent(colorize(config.getString("messages.prefix") + chatMessage));
+            TextComponent message = new TextComponent(prefixedLegacy(chatMessage));
             String command = "/" + getPrimaryCommand() + " view " + mailId;
             message.setClickEvent(new ClickEvent(ClickEvent.Action.RUN_COMMAND, command));
             receiver.spigot().sendMessage(message);
@@ -649,20 +703,16 @@ public class LamMailBox extends JavaPlugin implements Listener {
 
         // Title notification
         if (config.getBoolean("settings.notification.title-enabled")) {
-            String title = colorize(applyPlaceholderVariants(
-                    config.getString("titles.notification.title"),
-                    "sender",
-                    sender));
-            String subtitle = colorize(applyPlaceholderVariants(
-                    config.getString("titles.notification.subtitle"),
-                    "sender",
-                    sender));
-
-            int fadeIn = config.getInt("titles.notification.fadein");
-            int stay = config.getInt("titles.notification.stay");
-            int fadeOut = config.getInt("titles.notification.fadeout");
-
-            receiver.sendTitle(title, subtitle, fadeIn, stay, fadeOut);
+            yskLib.messageManager.sendTitle(
+                    this,
+                    receiver,
+                    "titles.notification.title",
+                    "titles.notification.subtitle",
+                    config.getInt("titles.notification.fadein"),
+                    config.getInt("titles.notification.stay"),
+                    config.getInt("titles.notification.fadeout"),
+                    MessageManager.placeholders("sender", sender)
+            );
         }
 
         // Sound notification

--- a/src/main/java/com/yusaki/lammailbox/LamMailBox.java
+++ b/src/main/java/com/yusaki/lammailbox/LamMailBox.java
@@ -816,7 +816,20 @@ public class LamMailBox extends JavaPlugin implements Listener {
     }
 
     private void updateCommandAliases() {
-        List<String> aliases = CommandAliasManager.applyAliases(this, "lmb", getConfig(), "settings.command-aliases.base");
+        FileConfiguration config = getConfig();
+        String primaryPath = "settings.command-aliases.lmb";
+        String legacyPath = "settings.command-aliases.base";
+
+        List<String> aliases;
+        if (config.contains(primaryPath)) {
+            aliases = CommandAliasManager.applyAliases(this, "lmb", config, primaryPath);
+            if (aliases.isEmpty() && config.contains(legacyPath)) {
+                aliases = CommandAliasManager.applyAliases(this, "lmb", config, legacyPath);
+            }
+        } else {
+            aliases = CommandAliasManager.applyAliases(this, "lmb", config, legacyPath);
+        }
+
         primaryCommand = aliases.isEmpty() ? "lmb" : aliases.get(0);
     }
 

--- a/src/main/java/com/yusaki/lammailbox/command/LmbCommandExecutor.java
+++ b/src/main/java/com/yusaki/lammailbox/command/LmbCommandExecutor.java
@@ -53,15 +53,12 @@ public class LmbCommandExecutor implements CommandExecutor {
     private boolean handleSend(CommandSender sender, String[] args) {
         FileConfiguration config = plugin.getConfig();
         if (!sender.hasPermission(config.getString("settings.admin-permission"))) {
-            sender.sendMessage(plugin.colorize(config.getString("messages.prefix") +
-                    config.getString("messages.send-command-admin-only")));
+            plugin.sendPrefixedMessage(sender, "messages.send-command-admin-only");
             return true;
         }
 
         if (args.length < 2) {
-            String usage = config.getString("messages.usage-send",
-                    "&cUsage: /lmb send <users> <message> | [commands] | schedule:YYYY:MM:DD:HH:mm | expire:YYYY:MM:DD:HH:mm");
-            sender.sendMessage(plugin.colorize(config.getString("messages.prefix") + usage));
+            plugin.sendPrefixedMessage(sender, "messages.usage-send");
             return true;
         }
 
@@ -87,8 +84,7 @@ public class LmbCommandExecutor implements CommandExecutor {
                 String dateStr = section.substring(9).trim();
                 scheduleDate = parseDateString(dateStr);
                 if (scheduleDate == null) {
-                    sender.sendMessage(plugin.colorize(config.getString("messages.prefix") +
-                            config.getString("messages.invalid-date-format")));
+                    plugin.sendPrefixedMessage(sender, "messages.invalid-date-format");
                     return true;
                 }
             } else if (section.startsWith("expire:")) {
@@ -96,15 +92,13 @@ public class LmbCommandExecutor implements CommandExecutor {
                 String dateStr = section.substring(7).trim();
                 expireDate = parseDateString(dateStr);
                 if (expireDate == null) {
-                    sender.sendMessage(plugin.colorize(config.getString("messages.prefix") +
-                            config.getString("messages.invalid-date-format")));
+                    plugin.sendPrefixedMessage(sender, "messages.invalid-date-format");
                     return true;
                 }
             } else if (!section.isEmpty()) {
                 // Parse commands section
                 if (sender instanceof Player && !sender.hasPermission(config.getString("settings.admin-permission"))) {
-                    sender.sendMessage(plugin.colorize(config.getString("messages.prefix") +
-                            config.getString("messages.no-permission")));
+                    plugin.sendPrefixedMessage(sender, "messages.no-permission");
                     return true;
                 }
 
@@ -161,19 +155,16 @@ public class LmbCommandExecutor implements CommandExecutor {
                 if (delivery.shouldNotifyNow()) {
                     plugin.dispatchMailNotifications(delivery.getReceiverSpec(), delivery.getMailId(), delivery.getSenderName());
                 }
-                player.sendMessage(plugin.colorize(config.getString("messages.prefix") +
-                        config.getString("messages.mail-sent")));
+                plugin.sendPrefixedMessage(player, "messages.mail-sent");
             } else {
                 MailDelivery delivery = plugin.getMailService().sendConsoleMail(sender, session);
                 if (delivery.shouldNotifyNow()) {
                     plugin.dispatchMailNotifications(delivery.getReceiverSpec(), delivery.getMailId(), delivery.getSenderName());
                 }
-                String consoleSent = config.getString("messages.mail-sent-console", "&aMail sent successfully.");
-                sender.sendMessage(plugin.colorize(config.getString("messages.prefix") + consoleSent));
+                plugin.sendPrefixedMessage(sender, "messages.mail-sent-console");
             }
         } catch (IllegalArgumentException ex) {
-            sender.sendMessage(plugin.colorize(config.getString("messages.prefix") +
-                    config.getString("messages.incomplete-mail")));
+            plugin.sendPrefixedMessage(sender, "messages.incomplete-mail");
         }
         return true;
     }
@@ -181,13 +172,12 @@ public class LmbCommandExecutor implements CommandExecutor {
     private boolean handleView(CommandSender sender, String[] args) {
         FileConfiguration config = plugin.getConfig();
         if (!(sender instanceof Player)) {
-            sender.sendMessage(plugin.colorize(config.getString("messages.console-only")));
+            plugin.sendPrefixedMessage(sender, "messages.console-only");
             return true;
         }
 
         if (args.length < 2) {
-            String usage = config.getString("messages.usage-view", "&cUsage: /lmb view <mailId>");
-            sender.sendMessage(plugin.colorize(config.getString("messages.prefix") + usage));
+            plugin.sendPrefixedMessage(sender, "messages.usage-view");
             return true;
         }
 
@@ -196,8 +186,7 @@ public class LmbCommandExecutor implements CommandExecutor {
 
         Optional<MailRecord> recordOpt = plugin.getMailRepository().findRecord(mailId);
         if (recordOpt.isEmpty()) {
-            player.sendMessage(plugin.colorize(config.getString("messages.prefix") +
-                    config.getString("messages.mail-not-found")));
+            plugin.sendPrefixedMessage(player, "messages.mail-not-found");
             return true;
         }
 
@@ -207,8 +196,7 @@ public class LmbCommandExecutor implements CommandExecutor {
         if (canAccess) {
             plugin.openMailView(player, mailId);
         } else {
-            player.sendMessage(plugin.colorize(config.getString("messages.prefix") +
-                    config.getString("messages.mail-no-access")));
+            plugin.sendPrefixedMessage(player, "messages.mail-no-access");
         }
         return true;
     }
@@ -216,34 +204,28 @@ public class LmbCommandExecutor implements CommandExecutor {
     private boolean handleAs(CommandSender sender, String[] args) {
         FileConfiguration config = plugin.getConfig();
         if (!sender.hasPermission(config.getString("settings.permissions.view-as"))) {
-            sender.sendMessage(plugin.colorize(config.getString("messages.prefix") +
-                    config.getString("messages.no-permission")));
+            plugin.sendPrefixedMessage(sender, "messages.no-permission");
             return true;
         }
 
         if (args.length < 2) {
-            String usage = config.getString("messages.usage-as", "&cUsage: /lmb as <player>");
-            sender.sendMessage(plugin.colorize(config.getString("messages.prefix") + usage));
+            plugin.sendPrefixedMessage(sender, "messages.usage-as");
             return true;
         }
 
         Player targetPlayer = Bukkit.getPlayer(args[1]);
         if (targetPlayer == null) {
-            sender.sendMessage(plugin.colorize(config.getString("messages.prefix") +
-                    config.getString("messages.invalid-receiver")));
+            plugin.sendPrefixedMessage(sender, "messages.invalid-receiver");
             return true;
         }
 
         if (sender instanceof Player) {
             Player admin = (Player) sender;
             plugin.openMailboxAsPlayer(admin, targetPlayer);
-            String message = config.getString("messages.mailbox-opened-as", "&aOpened mailbox as %player%");
-            admin.sendMessage(plugin.colorize(config.getString("messages.prefix") +
-                    plugin.applyPlaceholderVariants(message, "player", targetPlayer.getName())));
+            plugin.sendPrefixedMessage(admin, "messages.mailbox-opened-as",
+                    plugin.placeholders("player", targetPlayer.getName()));
         } else {
-            String warning = config.getString("messages.console-gui-warning",
-                    "&cConsole cannot open GUI. Use /lmb <player> instead.");
-            sender.sendMessage(plugin.colorize(config.getString("messages.prefix") + warning));
+            plugin.sendPrefixedMessage(sender, "messages.console-gui-warning");
         }
         return true;
     }
@@ -252,8 +234,7 @@ public class LmbCommandExecutor implements CommandExecutor {
         FileConfiguration config = plugin.getConfig();
         Player target = Bukkit.getPlayer(targetName);
         if (target == null) {
-            sender.sendMessage(plugin.colorize(config.getString("messages.prefix") +
-                    config.getString("messages.invalid-receiver")));
+            plugin.sendPrefixedMessage(sender, "messages.invalid-receiver");
             return true;
         }
 
@@ -261,24 +242,21 @@ public class LmbCommandExecutor implements CommandExecutor {
             Player player = (Player) sender;
             String permission = config.getString("settings.permissions.open-others", "lammailbox.open.others");
             if (!player.hasPermission(permission)) {
-                player.sendMessage(plugin.colorize(config.getString("messages.prefix") +
-                        config.getString("messages.no-permission")));
+                plugin.sendPrefixedMessage(player, "messages.no-permission");
                 return true;
             }
         }
 
         plugin.openMainGUI(target);
-        String message = config.getString("messages.mailbox-opened-for", "&aOpened mailbox for %player%");
-        sender.sendMessage(plugin.colorize(config.getString("messages.prefix") +
-                plugin.applyPlaceholderVariants(message, "player", target.getName())));
+        plugin.sendPrefixedMessage(sender, "messages.mailbox-opened-for",
+                plugin.placeholders("player", target.getName()));
         return true;
     }
 
     private boolean handleDefault(CommandSender sender) {
         FileConfiguration config = plugin.getConfig();
         if (!(sender instanceof Player)) {
-            String usage = config.getString("messages.usage-default", "&cUsage: /lmb <player>");
-            sender.sendMessage(plugin.colorize(config.getString("messages.prefix") + usage));
+            plugin.sendPrefixedMessage(sender, "messages.usage-default");
             return true;
         }
 
@@ -290,21 +268,19 @@ public class LmbCommandExecutor implements CommandExecutor {
     private boolean handleMailings(CommandSender sender) {
         FileConfiguration config = plugin.getConfig();
         if (!sender.hasPermission(config.getString("settings.admin-permission"))) {
-            sender.sendMessage(plugin.colorize(config.getString("messages.prefix") +
-                    config.getString("messages.no-permission")));
+            plugin.sendPrefixedMessage(sender, "messages.no-permission");
             return true;
         }
 
         List<MailingDefinition> definitions = plugin.getMailingDefinitions();
-        String prefix = config.getString("messages.prefix", "");
         String header = plugin.getMailingsMessage("header", "&6Mailings:");
         String empty = plugin.getMailingsMessage("empty", "&7No mailings configured.");
         if (definitions.isEmpty()) {
-            sender.sendMessage(plugin.colorize(prefix + empty));
+            plugin.sendPrefixedRaw(sender, empty);
             return true;
         }
 
-        sender.sendMessage(plugin.colorize(prefix + header));
+        plugin.sendPrefixedRaw(sender, header);
         var statusRepository = plugin.getMailingStatusRepository();
         var scheduler = plugin.getMailingScheduler();
         String repeatingTemplate = plugin.getMailingsMessage("entry-repeating",
@@ -363,7 +339,7 @@ public class LmbCommandExecutor implements CommandExecutor {
                     "runs", runsSegment,
                     "completed", completedSegment));
 
-            sender.sendMessage(plugin.colorize(prefix + line));
+            plugin.sendPrefixedRaw(sender, line);
         }
         return true;
     }

--- a/src/main/java/com/yusaki/lammailbox/command/LmbMigrateCommand.java
+++ b/src/main/java/com/yusaki/lammailbox/command/LmbMigrateCommand.java
@@ -24,16 +24,15 @@ public class LmbMigrateCommand implements CommandExecutor {
     @Override
     public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
         FileConfiguration config = plugin.getConfig();
-        String prefix = plugin.colorize(config.getString("messages.prefix"));
         String permission = config.getString("settings.permissions.migrate", "lammailbox.migrate");
 
         if (!sender.hasPermission(permission)) {
-            sender.sendMessage(plugin.colorize(prefix + config.getString("messages.no-permission")));
+            plugin.sendPrefixedMessage(sender, "messages.no-permission");
             return true;
         }
 
         if (args.length < 2) {
-            sender.sendMessage(plugin.colorize(prefix + config.getString("messages.migrate-usage", "&cUsage: /lmbmigrate <source> <target>")));
+            plugin.sendPrefixedMessage(sender, "messages.migrate-usage");
             return true;
         }
 
@@ -41,21 +40,17 @@ public class LmbMigrateCommand implements CommandExecutor {
         StorageSettings.BackendType targetType = parseBackend(args[1]);
 
         if (sourceType == null) {
-            sender.sendMessage(plugin.colorize(prefix + plugin.applyPlaceholderVariants(
-                    config.getString("messages.migrate-invalid", "&c✖ Unknown storage type: %type%"),
-                    "type",
-                    args[0].toLowerCase(Locale.ROOT))));
+            plugin.sendPrefixedMessage(sender, "messages.migrate-invalid",
+                    plugin.placeholders("type", args[0].toLowerCase(Locale.ROOT)));
             return true;
         }
         if (targetType == null) {
-            sender.sendMessage(plugin.colorize(prefix + plugin.applyPlaceholderVariants(
-                    config.getString("messages.migrate-invalid", "&c✖ Unknown storage type: %type%"),
-                    "type",
-                    args[1].toLowerCase(Locale.ROOT))));
+            plugin.sendPrefixedMessage(sender, "messages.migrate-invalid",
+                    plugin.placeholders("type", args[1].toLowerCase(Locale.ROOT)));
             return true;
         }
         if (sourceType == targetType) {
-            sender.sendMessage(plugin.colorize(prefix + config.getString("messages.migrate-same", "&c✖ Source and target storage must be different.")));
+            plugin.sendPrefixedMessage(sender, "messages.migrate-same");
             return true;
         }
 
@@ -72,29 +67,25 @@ public class LmbMigrateCommand implements CommandExecutor {
 
             List<String> sourceIds = sourceRepo.listMailIds();
             if (sourceIds.isEmpty()) {
-                sender.sendMessage(plugin.colorize(prefix + plugin.applyPlaceholderVariants(
-                        config.getString("messages.migrate-empty", "&eNo mail entries found in %source% storage."),
-                        "source",
-                        args[0].toLowerCase(Locale.ROOT))));
+                plugin.sendPrefixedMessage(sender, "messages.migrate-empty",
+                        plugin.placeholders("source", args[0].toLowerCase(Locale.ROOT)));
                 return true;
             }
 
             // Check if target database is empty before proceeding
             List<String> targetIds = targetRepo.listMailIds();
             if (!targetIds.isEmpty()) {
-                String template = config.getString("messages.migrate-target-not-empty",
-                        "&c✖ Target storage contains %count% mail entries. Please clear the target storage first or choose an empty target.");
-                sender.sendMessage(plugin.colorize(prefix + plugin.applyPlaceholderVariants(template, Map.of(
-                        "count", String.valueOf(targetIds.size()),
-                        "target", args[1].toLowerCase(Locale.ROOT)))));
+                plugin.sendPrefixedMessage(sender, "messages.migrate-target-not-empty",
+                        plugin.placeholders(
+                                "count", String.valueOf(targetIds.size()),
+                                "target", args[1].toLowerCase(Locale.ROOT)));
                 return true;
             }
 
-            String startTemplate = config.getString("messages.migrate-start",
-                    "&eMigrating mail from &f%source% &eto &f%target%&e...");
-            sender.sendMessage(plugin.colorize(prefix + plugin.applyPlaceholderVariants(startTemplate, Map.of(
-                    "source", args[0].toLowerCase(Locale.ROOT),
-                    "target", args[1].toLowerCase(Locale.ROOT)))));
+            plugin.sendPrefixedMessage(sender, "messages.migrate-start",
+                    plugin.placeholders(
+                            "source", args[0].toLowerCase(Locale.ROOT),
+                            "target", args[1].toLowerCase(Locale.ROOT)));
 
             int migrated = 0;
             for (String mailId : sourceIds) {
@@ -106,19 +97,14 @@ public class LmbMigrateCommand implements CommandExecutor {
             }
             targetRepo.save();
 
-            String successTemplate = config.getString("messages.migrate-success",
-                    "&a✔ Migration complete: %count% mails moved to %target%.");
-            String successMessage = plugin.applyPlaceholderVariants(successTemplate, Map.of(
-                    "count", String.valueOf(migrated),
-                    "target", args[1].toLowerCase(Locale.ROOT)));
-            sender.sendMessage(plugin.colorize(prefix + successMessage));
+            plugin.sendPrefixedMessage(sender, "messages.migrate-success",
+                    plugin.placeholders(
+                            "count", String.valueOf(migrated),
+                            "target", args[1].toLowerCase(Locale.ROOT)));
         } catch (Exception ex) {
             plugin.getLogger().severe("Migration failed: " + ex.getMessage());
-            String errorTemplate = config.getString("messages.migrate-error", "&c✖ Migration failed: %error%");
-            String errorMessage = plugin.applyPlaceholderVariants(errorTemplate,
-                    "error",
-                    Optional.ofNullable(ex.getMessage()).orElse("unknown"));
-            sender.sendMessage(plugin.colorize(prefix + errorMessage));
+            plugin.sendPrefixedMessage(sender, "messages.migrate-error",
+                    plugin.placeholders("error", Optional.ofNullable(ex.getMessage()).orElse("unknown")));
         } finally {
             if (!reuseSource && sourceRepo != null) {
                 sourceRepo.shutdown();

--- a/src/main/java/com/yusaki/lammailbox/config/MailBoxConfigUpdater.java
+++ b/src/main/java/com/yusaki/lammailbox/config/MailBoxConfigUpdater.java
@@ -98,8 +98,12 @@ public class MailBoxConfigUpdater {
         if (aliasSection == null) {
             aliasSection = config.createSection("settings.command-aliases");
         }
-        if (!aliasSection.contains("base")) {
-            aliasSection.set("base", Arrays.asList("mailbox", "mail", "mb"));
+        if (!aliasSection.contains("lmb")) {
+            var aliases = aliasSection.getStringList("base");
+            if (aliases == null || aliases.isEmpty()) {
+                aliases = Arrays.asList("mailbox", "mail", "mb");
+            }
+            aliasSection.set("lmb", aliases);
         }
 
         // Add any config-specific migrations here

--- a/src/main/java/com/yusaki/lammailbox/gui/CommandItemUiComposer.java
+++ b/src/main/java/com/yusaki/lammailbox/gui/CommandItemUiComposer.java
@@ -74,7 +74,7 @@ final class CommandItemUiComposer {
                 .map(line -> plugin.applyPlaceholderVariants(line,
                         "count",
                         String.valueOf(session.getCommandItems().size())))
-                .map(plugin::colorize)
+                .map(plugin::legacy)
                 .collect(Collectors.toList());
 
         if (!session.getCommandItems().isEmpty()) {
@@ -126,9 +126,9 @@ final class CommandItemUiComposer {
             return item;
         }
 
-        meta.setDisplayName(plugin.colorize(config().getString(path + ".name", "&c" + action)));
+        meta.setDisplayName(plugin.legacy(config().getString(path + ".name", "&c" + action)));
         meta.setLore(config().getStringList(path + ".lore").stream()
-                .map(plugin::colorize)
+                .map(plugin::legacy)
                 .collect(Collectors.toList()));
         itemStyler.apply(meta, path);
         meta.getPersistentDataContainer().set(commandItemActionKey, PersistentDataType.STRING, action);
@@ -158,12 +158,12 @@ final class CommandItemUiComposer {
         }
 
         String name = config().getString(path + ".name", "&eEdit");
-        meta.setDisplayName(plugin.colorize(applyPlaceholders(name, placeholders)));
+        meta.setDisplayName(plugin.legacy(applyPlaceholders(name, placeholders)));
 
         List<String> loreTemplate = config().getStringList(path + ".lore");
         List<String> lore = loreTemplate.stream()
                 .map(line -> applyDraftPlaceholders(line, placeholders, draft))
-                .map(plugin::colorize)
+                .map(plugin::legacy)
                 .collect(Collectors.toList());
 
         if ("lore".equals(action) && !draft.lore().isEmpty()) {
@@ -172,7 +172,7 @@ final class CommandItemUiComposer {
             appendDetailLines(lore, "&7Commands:", draft.commands(), 10, true);
         } else if ("custom-model".equals(action)) {
             String value = draft.customModelData() != null ? String.valueOf(draft.customModelData()) : "None";
-            lore.add(plugin.colorize("&7Current: &f" + value));
+            lore.add(plugin.legacy("&7Current: &f" + value));
         }
 
         if (!lore.isEmpty()) {
@@ -235,13 +235,13 @@ final class CommandItemUiComposer {
         Map<String, String> placeholders = createCommandItemPlaceholders(commandItem);
         String overrideName = config().getString(legacyPath + ".name");
         if (overrideName != null && !overrideName.isBlank()) {
-            meta.setDisplayName(plugin.colorize(applyPlaceholders(overrideName, placeholders)));
+            meta.setDisplayName(plugin.legacy(applyPlaceholders(overrideName, placeholders)));
         }
 
         List<String> configuredLore = config().getStringList(legacyPath + ".lore");
         if (!configuredLore.isEmpty()) {
             List<String> lore = configuredLore.stream()
-                    .map(line -> plugin.colorize(applyPlaceholders(line, placeholders)))
+                    .map(line -> plugin.legacy(applyPlaceholders(line, placeholders)))
                     .collect(Collectors.toList());
             meta.setLore(lore);
         }
@@ -277,10 +277,10 @@ final class CommandItemUiComposer {
             return;
         }
         if (!lore.isEmpty()) {
-            lore.add(plugin.colorize("&7"));
+            lore.add(plugin.legacy("&7"));
         }
         lore.addAll(actionLore.stream()
-                .map(plugin::colorize)
+                .map(plugin::legacy)
                 .collect(Collectors.toList()));
     }
 
@@ -293,15 +293,15 @@ final class CommandItemUiComposer {
             return;
         }
         if (!target.isEmpty()) {
-            target.add(plugin.colorize("&7"));
+            target.add(plugin.legacy("&7"));
         }
-        target.add(plugin.colorize(header));
+        target.add(plugin.legacy(header));
         for (String value : values.stream().limit(limit).toList()) {
             String text = summarizeCommands ? Optional.ofNullable(summarizeCommand(value)).orElse(value) : value;
-            target.add(plugin.colorize("&f• " + text));
+            target.add(plugin.legacy("&f• " + text));
         }
         if (values.size() > limit) {
-            target.add(plugin.colorize("&7…"));
+            target.add(plugin.legacy("&7…"));
         }
     }
 

--- a/src/main/java/com/yusaki/lammailbox/gui/CommandItemsClickActions.java
+++ b/src/main/java/com/yusaki/lammailbox/gui/CommandItemsClickActions.java
@@ -119,7 +119,7 @@ final class CommandItemsClickActions {
                     : draft != null && draft.removeLastCommand();
             String messageKey = isLore ? (removed ? "messages.command-item-lore-removed" : "messages.command-item-lore-empty")
                     : (removed ? "messages.command-item-command-removed" : "messages.command-item-command-empty");
-            player.sendMessage(plugin.colorize(config().getString("messages.prefix") +
+            player.sendMessage(plugin.legacy(config().getString("messages.prefix") +
                     config().getString(messageKey)));
             plugin.openCommandItemCreator(player);
         } else {
@@ -135,7 +135,7 @@ final class CommandItemsClickActions {
         if (event.isRightClick()) {
             if (draft != null) {
                 draft.customModelData(null);
-                player.sendMessage(plugin.colorize(config().getString("messages.prefix") +
+                player.sendMessage(plugin.legacy(config().getString("messages.prefix") +
                         config().getString("messages.command-item-model-cleared")));
             }
             plugin.openCommandItemCreator(player);
@@ -166,7 +166,7 @@ final class CommandItemsClickActions {
         plugin.getInMailCreation().put(player.getUniqueId(), true);
         plugin.getMailCreationController().showInputTitle(player, titleKey);
         if (message != null) {
-            player.sendMessage(plugin.colorize(config().getString("messages.prefix") + message));
+            player.sendMessage(plugin.legacy(config().getString("messages.prefix") + message));
         }
         player.closeInventory();
     }

--- a/src/main/java/com/yusaki/lammailbox/gui/ConfigMailGuiFactory.java
+++ b/src/main/java/com/yusaki/lammailbox/gui/ConfigMailGuiFactory.java
@@ -89,7 +89,7 @@ public class ConfigMailGuiFactory implements MailGuiFactory {
     private void applyCommandIconText(ItemMeta meta, String basePath, int commandCount, String summary) {
         String displayName = config().getString(basePath + ".name");
         if (displayName != null && !displayName.isBlank()) {
-            meta.setDisplayName(plugin.colorize(format(displayName,
+            meta.setDisplayName(plugin.legacy(format(displayName,
                     "count", String.valueOf(commandCount),
                     "summary", summary)));
         }
@@ -99,7 +99,7 @@ public class ConfigMailGuiFactory implements MailGuiFactory {
             rawLore = Collections.singletonList("&7Contains hidden console actions");
         }
         List<String> lore = rawLore.stream()
-                .map(line -> plugin.colorize(format(line,
+                .map(line -> plugin.legacy(format(line,
                         "count", String.valueOf(commandCount),
                         "summary", summary)))
                 .collect(Collectors.toList());
@@ -178,7 +178,7 @@ public class ConfigMailGuiFactory implements MailGuiFactory {
     @Override
     public Inventory createMailbox(Player viewer) {
         int size = config().getInt("gui.main.size");
-        Inventory inv = Bukkit.createInventory(null, size, plugin.colorize(config().getString("gui.main.title")));
+        Inventory inv = Bukkit.createInventory(null, size, plugin.legacy(config().getString("gui.main.title")));
         addDecorations(inv, "gui.main");
 
         addCreateMailButton(inv, viewer, viewer);
@@ -191,7 +191,7 @@ public class ConfigMailGuiFactory implements MailGuiFactory {
     public Inventory createMailboxAs(Player admin, Player target) {
         int size = config().getInt("gui.main.size");
         String title = config().getString("gui.main.title") + " &7(as " + target.getName() + ")";
-        Inventory inv = Bukkit.createInventory(null, size, plugin.colorize(title));
+        Inventory inv = Bukkit.createInventory(null, size, plugin.legacy(title));
         addDecorations(inv, "gui.main");
 
         addCreateMailButton(inv, admin, target);
@@ -208,7 +208,7 @@ public class ConfigMailGuiFactory implements MailGuiFactory {
         if (viewingAs != null) {
             title += " &7(as " + viewingAs + ")";
         }
-        Inventory inv = Bukkit.createInventory(null, size, plugin.colorize(title));
+        Inventory inv = Bukkit.createInventory(null, size, plugin.legacy(title));
         addDecorations(inv, "gui.sent-mail");
 
         addBackButton(inv);
@@ -219,7 +219,7 @@ public class ConfigMailGuiFactory implements MailGuiFactory {
     @Override
     public Inventory createSentMailView(Player viewer, String mailId) {
         int size = config().getInt("gui.sent-mail-view.size");
-        Inventory inv = Bukkit.createInventory(null, size, plugin.colorize(config().getString("gui.sent-mail-view.title")));
+        Inventory inv = Bukkit.createInventory(null, size, plugin.legacy(config().getString("gui.sent-mail-view.title")));
         addDecorations(inv, "gui.sent-mail-view");
 
         Optional<MailRecord> recordOpt = plugin.getMailRepository().findRecord(mailId);
@@ -234,7 +234,7 @@ public class ConfigMailGuiFactory implements MailGuiFactory {
         if (isEnabled("gui.sent-mail-view.items.receiver-head")) {
             ItemStack head = new ItemStack(Material.valueOf(config().getString("gui.sent-mail-view.items.receiver-head.material")));
             SkullMeta headMeta = (SkullMeta) head.getItemMeta();
-            headMeta.setDisplayName(plugin.colorize(format(
+            headMeta.setDisplayName(plugin.legacy(format(
                     config().getString("gui.sent-mail-view.items.receiver-head.name"),
                     "receiver",
                     receiver)));
@@ -250,9 +250,9 @@ public class ConfigMailGuiFactory implements MailGuiFactory {
         if (isEnabled("gui.sent-mail-view.items.message")) {
             ItemStack messageItem = new ItemStack(Material.valueOf(config().getString("gui.sent-mail-view.items.message.material")));
             ItemMeta messageMeta = messageItem.getItemMeta();
-            messageMeta.setDisplayName(plugin.colorize(config().getString("gui.sent-mail-view.items.message.name")));
+            messageMeta.setDisplayName(plugin.legacy(config().getString("gui.sent-mail-view.items.message.name")));
             List<String> messageLore = Arrays.stream(message.split("\n"))
-                    .map(line -> plugin.colorize("&f" + line))
+                    .map(line -> plugin.legacy("&f" + line))
                     .collect(Collectors.toList());
             messageMeta.setLore(messageLore);
             itemStyler.apply(messageMeta, "gui.sent-mail-view.items.message", false);
@@ -277,9 +277,9 @@ public class ConfigMailGuiFactory implements MailGuiFactory {
                 && isEnabled("gui.sent-mail-view.items.delete-button")) {
             ItemStack deleteButton = new ItemStack(Material.valueOf(config().getString("gui.sent-mail-view.items.delete-button.material")));
             ItemMeta deleteMeta = deleteButton.getItemMeta();
-            deleteMeta.setDisplayName(plugin.colorize(config().getString("gui.sent-mail-view.items.delete-button.name")));
+            deleteMeta.setDisplayName(plugin.legacy(config().getString("gui.sent-mail-view.items.delete-button.name")));
             deleteMeta.setLore(config().getStringList("gui.sent-mail-view.items.delete-button.lore").stream()
-                    .map(plugin::colorize)
+                    .map(plugin::legacy)
                     .collect(Collectors.toList()));
             deleteMeta.getPersistentDataContainer().set(mailIdKey,
                     PersistentDataType.STRING, mailId);
@@ -295,7 +295,7 @@ public class ConfigMailGuiFactory implements MailGuiFactory {
     @Override
     public Inventory createMailView(Player viewer, String mailId) {
         int size = config().getInt("gui.mail-view.size");
-        Inventory inv = Bukkit.createInventory(null, size, plugin.colorize(config().getString("gui.mail-view.title")));
+        Inventory inv = Bukkit.createInventory(null, size, plugin.legacy(config().getString("gui.mail-view.title")));
         addDecorations(inv, "gui.mail-view");
 
         Optional<MailRecord> recordOpt = plugin.getMailRepository().findRecord(mailId);
@@ -310,7 +310,7 @@ public class ConfigMailGuiFactory implements MailGuiFactory {
         if (isEnabled("gui.mail-view.items.sender-head")) {
             ItemStack head = new ItemStack(Material.valueOf(config().getString("gui.mail-view.items.sender-head.material")));
             SkullMeta headMeta = (SkullMeta) head.getItemMeta();
-            headMeta.setDisplayName(plugin.colorize(format(
+            headMeta.setDisplayName(plugin.legacy(format(
                     config().getString("gui.mail-view.items.sender-head.name"),
                     "sender",
                     sender)));
@@ -326,9 +326,9 @@ public class ConfigMailGuiFactory implements MailGuiFactory {
         if (isEnabled("gui.mail-view.items.message")) {
             ItemStack messageItem = new ItemStack(Material.valueOf(config().getString("gui.mail-view.items.message.material")));
             ItemMeta messageMeta = messageItem.getItemMeta();
-            messageMeta.setDisplayName(plugin.colorize(config().getString("gui.mail-view.items.message.name")));
+            messageMeta.setDisplayName(plugin.legacy(config().getString("gui.mail-view.items.message.name")));
             List<String> messageLore = Arrays.stream(message.split("\n"))
-                    .map(line -> plugin.colorize("&f" + line))
+                    .map(line -> plugin.legacy("&f" + line))
                     .collect(Collectors.toList());
             messageMeta.setLore(messageLore);
             itemStyler.apply(messageMeta, "gui.mail-view.items.message", false);
@@ -372,9 +372,9 @@ public class ConfigMailGuiFactory implements MailGuiFactory {
         if (claimSlot != null) {
             ItemStack claimButton = new ItemStack(Material.valueOf(config().getString("gui.mail-view.items.claim-button.material")));
             ItemMeta claimMeta = claimButton.getItemMeta();
-            claimMeta.setDisplayName(plugin.colorize(config().getString("gui.mail-view.items.claim-button.name")));
+            claimMeta.setDisplayName(plugin.legacy(config().getString("gui.mail-view.items.claim-button.name")));
             claimMeta.setLore(config().getStringList("gui.mail-view.items.claim-button.lore").stream()
-                    .map(plugin::colorize)
+                    .map(plugin::legacy)
                     .collect(Collectors.toList()));
             claimMeta.getPersistentDataContainer().set(mailIdKey,
                     PersistentDataType.STRING, mailId);
@@ -386,9 +386,9 @@ public class ConfigMailGuiFactory implements MailGuiFactory {
         if (dismissSlot != null) {
             ItemStack dismissButton = new ItemStack(Material.valueOf(config().getString("gui.mail-view.items.dismiss-button.material")));
             ItemMeta dismissMeta = dismissButton.getItemMeta();
-            dismissMeta.setDisplayName(plugin.colorize(config().getString("gui.mail-view.items.dismiss-button.name")));
+            dismissMeta.setDisplayName(plugin.legacy(config().getString("gui.mail-view.items.dismiss-button.name")));
             dismissMeta.setLore(config().getStringList("gui.mail-view.items.dismiss-button.lore").stream()
-                    .map(plugin::colorize)
+                    .map(plugin::legacy)
                     .collect(Collectors.toList()));
             dismissMeta.getPersistentDataContainer().set(mailIdKey,
                     PersistentDataType.STRING, mailId);
@@ -430,13 +430,13 @@ public class ConfigMailGuiFactory implements MailGuiFactory {
         ItemStack createBook = new ItemStack(Material.valueOf(config().getString("gui.main.items.create-mail.material")));
         ItemMeta bookMeta = createBook.getItemMeta();
         String baseName = config().getString("gui.main.items.create-mail.name", "");
-        bookMeta.setDisplayName(plugin.colorize(baseName));
+        bookMeta.setDisplayName(plugin.legacy(baseName));
         List<String> bookLore = new ArrayList<>(config().getStringList("gui.main.items.create-mail.lore"));
 
         String viewingAs = plugin.getViewingAsPlayer().get(viewer.getUniqueId());
         if (viewingAs != null && !viewer.getUniqueId().equals(target.getUniqueId())) {
             String disabledNameFormat = config().getString("gui.main.items.create-mail.disabled.name-format", "&c&l%name%");
-            bookMeta.setDisplayName(plugin.colorize(format(disabledNameFormat, "name", baseName)));
+            bookMeta.setDisplayName(plugin.legacy(format(disabledNameFormat, "name", baseName)));
             List<String> disabledLore = config().getStringList("gui.main.items.create-mail.disabled.lore");
             if (!disabledLore.isEmpty()) {
                 bookLore.addAll(disabledLore);
@@ -446,7 +446,7 @@ public class ConfigMailGuiFactory implements MailGuiFactory {
             }
         }
 
-        bookMeta.setLore(bookLore.stream().map(plugin::colorize).collect(Collectors.toList()));
+        bookMeta.setLore(bookLore.stream().map(plugin::legacy).collect(Collectors.toList()));
         itemStyler.apply(bookMeta, "gui.main.items.create-mail");
         createBook.setItemMeta(bookMeta);
         inv.setItem(config().getInt("gui.main.items.create-mail.slot"), createBook);
@@ -458,9 +458,9 @@ public class ConfigMailGuiFactory implements MailGuiFactory {
         }
         ItemStack sentMailButton = new ItemStack(Material.valueOf(config().getString("gui.main.items.sent-mail.material")));
         ItemMeta sentMailMeta = sentMailButton.getItemMeta();
-        sentMailMeta.setDisplayName(plugin.colorize(config().getString("gui.main.items.sent-mail.name")));
+        sentMailMeta.setDisplayName(plugin.legacy(config().getString("gui.main.items.sent-mail.name")));
         sentMailMeta.setLore(config().getStringList("gui.main.items.sent-mail.lore").stream()
-                .map(plugin::colorize)
+                .map(plugin::legacy)
                 .collect(Collectors.toList()));
         itemStyler.apply(sentMailMeta, "gui.main.items.sent-mail");
         sentMailButton.setItemMeta(sentMailMeta);
@@ -473,9 +473,9 @@ public class ConfigMailGuiFactory implements MailGuiFactory {
         }
         ItemStack backButton = new ItemStack(Material.valueOf(config().getString("gui.sent-mail.items.back-button.material")));
         ItemMeta backMeta = backButton.getItemMeta();
-        backMeta.setDisplayName(plugin.colorize(config().getString("gui.sent-mail.items.back-button.name")));
+        backMeta.setDisplayName(plugin.legacy(config().getString("gui.sent-mail.items.back-button.name")));
         backMeta.setLore(config().getStringList("gui.sent-mail.items.back-button.lore").stream()
-                .map(plugin::colorize)
+                .map(plugin::legacy)
                 .collect(Collectors.toList()));
         itemStyler.apply(backMeta, "gui.sent-mail.items.back-button");
         backButton.setItemMeta(backMeta);
@@ -628,18 +628,18 @@ public class ConfigMailGuiFactory implements MailGuiFactory {
         long sentAt = record.sentDate();
         long expireAt = record.expireDate() != null ? record.expireDate() : 0L;
 
-        meta.setDisplayName(plugin.colorize(applyMailPlaceholders(displayName, sender, message, sentAt, expireAt)));
+        meta.setDisplayName(plugin.legacy(applyMailPlaceholders(displayName, sender, message, sentAt, expireAt)));
 
         List<String> loreTemplate = config().getStringList(itemPath + ".lore");
         List<String> lore = new ArrayList<>();
         for (String line : loreTemplate) {
-            lore.add(plugin.colorize(applyMailPlaceholders(line, sender, message, sentAt, expireAt)));
+            lore.add(plugin.legacy(applyMailPlaceholders(line, sender, message, sentAt, expireAt)));
         }
 
         String messagePrefix = config().getString(itemPath + ".message-prefix");
         if (messagePrefix != null && !messagePrefix.isEmpty() && !message.isEmpty()) {
             for (String line : message.split("\n")) {
-                lore.add(plugin.colorize(messagePrefix + line));
+                lore.add(plugin.legacy(messagePrefix + line));
             }
         }
 
@@ -661,13 +661,13 @@ public class ConfigMailGuiFactory implements MailGuiFactory {
         long expireAt = record.expireDate() != null ? record.expireDate() : 0L;
 
         String displayName = config().getString("gui.sent-mail.items.sent-mail-display.name", "");
-        meta.setDisplayName(plugin.colorize(format(displayName,
+        meta.setDisplayName(plugin.legacy(format(displayName,
                 "receiver", receiver,
                 "sent_date", formatDate(sentAt),
                 "expire_date", formatDate(expireAt))));
 
         List<String> lore = config().getStringList("gui.sent-mail.items.sent-mail-display.lore").stream()
-                .map(line -> plugin.colorize(format(line,
+                .map(line -> plugin.legacy(format(line,
                         "receiver", receiver,
                         "sent_date", formatDate(sentAt),
                         "expire_date", formatDate(expireAt),
@@ -715,7 +715,7 @@ public class ConfigMailGuiFactory implements MailGuiFactory {
 
     private String formatDate(long millis) {
         if (millis <= 0) {
-            return plugin.colorize(config().getString("messages.never-expire", "Never"));
+            return plugin.legacy(config().getString("messages.never-expire", "Never"));
         }
         return new Date(millis).toString();
     }
@@ -739,11 +739,11 @@ public class ConfigMailGuiFactory implements MailGuiFactory {
 
             ItemStack decorItem = new ItemStack(material);
             ItemMeta meta = decorItem.getItemMeta();
-            meta.setDisplayName(plugin.colorize(name));
+            meta.setDisplayName(plugin.legacy(name));
             List<String> loreLines = config().getStringList(path + ".lore");
             if (!loreLines.isEmpty()) {
                 meta.setLore(loreLines.stream()
-                        .map(plugin::colorize)
+                        .map(plugin::legacy)
                         .collect(Collectors.toList()));
             }
             // Always mark decorations with the decoration key so they can be replaced by pagination buttons

--- a/src/main/java/com/yusaki/lammailbox/gui/GuiCloseHandler.java
+++ b/src/main/java/com/yusaki/lammailbox/gui/GuiCloseHandler.java
@@ -30,9 +30,9 @@ final class GuiCloseHandler {
         String title = event.getView().getTitle();
         UUID playerId = player.getUniqueId();
 
-        if (title.equals(plugin.colorize(config().getString("gui.items.title")))) {
+        if (title.equals(plugin.legacy(config().getString("gui.items.title")))) {
             handleItemsClose(event, player);
-        } else if (title.equals(plugin.colorize(config().getString("gui.create-mail.title")))) {
+        } else if (title.equals(plugin.legacy(config().getString("gui.create-mail.title")))) {
             handleCreateMailClose(player);
         }
 
@@ -85,8 +85,8 @@ final class GuiCloseHandler {
     }
 
     private void handleMainGuiClose(Player player, String title) {
-        String mainTitle = plugin.colorize(config().getString("gui.main.title"));
-        String mainViewingPrefix = plugin.colorize(config().getString("gui.main.title") + " &7(as ");
+        String mainTitle = plugin.legacy(config().getString("gui.main.title"));
+        String mainViewingPrefix = plugin.legacy(config().getString("gui.main.title") + " &7(as ");
         if (!title.equals(mainTitle) && !title.startsWith(mainViewingPrefix)) {
             return;
         }
@@ -109,8 +109,8 @@ final class GuiCloseHandler {
     }
 
     private void handleSentGuiClose(Player player, String title) {
-        String sentTitle = plugin.colorize(config().getString("gui.sent-mail.title"));
-        String sentViewingPrefix = plugin.colorize(config().getString("gui.sent-mail.title") + " &7(as ");
+        String sentTitle = plugin.legacy(config().getString("gui.sent-mail.title"));
+        String sentViewingPrefix = plugin.legacy(config().getString("gui.sent-mail.title") + " &7(as ");
         if (!title.equals(sentTitle) && !title.startsWith(sentViewingPrefix)) {
             return;
         }
@@ -131,7 +131,7 @@ final class GuiCloseHandler {
     }
 
     private void handleMailViewClose(Player player, String title) {
-        String mailViewTitle = plugin.colorize(config().getString("gui.mail-view.title"));
+        String mailViewTitle = plugin.legacy(config().getString("gui.mail-view.title"));
         if (!title.equals(mailViewTitle)) {
             return;
         }

--- a/src/main/java/com/yusaki/lammailbox/gui/GuiItemStyler.java
+++ b/src/main/java/com/yusaki/lammailbox/gui/GuiItemStyler.java
@@ -46,7 +46,7 @@ final class GuiItemStyler {
         }
 
         List<String> colorized = loreLines.stream()
-                .map(plugin::colorize)
+                .map(plugin::legacy)
                 .collect(Collectors.toList());
         meta.setLore(colorized);
     }

--- a/src/main/java/com/yusaki/lammailbox/gui/GuiNavigationHelper.java
+++ b/src/main/java/com/yusaki/lammailbox/gui/GuiNavigationHelper.java
@@ -44,7 +44,7 @@ final class GuiNavigationHelper {
         }
 
         String name = config.getString(path + ".name", "&cBack");
-        meta.setDisplayName(plugin.colorize(name));
+        meta.setDisplayName(plugin.legacy(name));
 
         itemStyler.apply(meta, path);
         meta.getPersistentDataContainer().set(actionKey, PersistentDataType.STRING, action);

--- a/src/main/java/com/yusaki/lammailbox/gui/InventoryClickHandler.java
+++ b/src/main/java/com/yusaki/lammailbox/gui/InventoryClickHandler.java
@@ -58,8 +58,8 @@ public class InventoryClickHandler implements MailInventoryHandler {
         String title = event.getView().getTitle();
         ItemStack clicked = event.getCurrentItem();
 
-        String mainTitle = plugin.colorize(config().getString("gui.main.title"));
-        String mainViewingPrefix = plugin.colorize(config().getString("gui.main.title") + " &7(as ");
+        String mainTitle = plugin.legacy(config().getString("gui.main.title"));
+        String mainViewingPrefix = plugin.legacy(config().getString("gui.main.title") + " &7(as ");
         boolean isMainGUI = title.equals(mainTitle) || title.startsWith(mainViewingPrefix);
 
         if (isMainGUI && event.getClickedInventory() == player.getInventory()) {
@@ -70,22 +70,22 @@ public class InventoryClickHandler implements MailInventoryHandler {
             return;
         }
 
-        String sentTitle = plugin.colorize(config().getString("gui.sent-mail.title"));
-        String sentViewingPrefix = plugin.colorize(config().getString("gui.sent-mail.title") + " &7(as ");
-        String commandItemsTitle = plugin.colorize(config().getString("gui.command-items-editor.title", "Command Items"));
-        String commandItemCreatorTitle = plugin.colorize(config().getString("gui.command-item-creator.title", "Create Command Item"));
+        String sentTitle = plugin.legacy(config().getString("gui.sent-mail.title"));
+        String sentViewingPrefix = plugin.legacy(config().getString("gui.sent-mail.title") + " &7(as ");
+        String commandItemsTitle = plugin.legacy(config().getString("gui.command-items-editor.title", "Command Items"));
+        String commandItemCreatorTitle = plugin.legacy(config().getString("gui.command-item-creator.title", "Create Command Item"));
 
         if (isMainGUI) {
             mainGuiActions.handle(event, player, clicked);
         } else if (title.equals(sentTitle) || title.startsWith(sentViewingPrefix)) {
             sentMailActions.handleListClick(event, player, clicked);
-        } else if (title.equals(plugin.colorize(config().getString("gui.sent-mail-view.title")))) {
+        } else if (title.equals(plugin.legacy(config().getString("gui.sent-mail-view.title")))) {
             sentMailActions.handleDetailClick(event, player, clicked);
-        } else if (title.equals(plugin.colorize(config().getString("gui.create-mail.title")))) {
+        } else if (title.equals(plugin.legacy(config().getString("gui.create-mail.title")))) {
             mailCreationActions.handle(event);
-        } else if (title.equals(plugin.colorize(config().getString("gui.items.title")))) {
+        } else if (title.equals(plugin.legacy(config().getString("gui.items.title")))) {
             itemsGuiActions.handle(event);
-        } else if (title.equals(plugin.colorize(config().getString("gui.mail-view.title")))) {
+        } else if (title.equals(plugin.legacy(config().getString("gui.mail-view.title")))) {
             mailViewActions.handle(event, player, clicked);
         } else if (title.equals(commandItemsTitle)) {
             commandItemsActions.handleEditorClick(event, player, clicked);

--- a/src/main/java/com/yusaki/lammailbox/gui/MailCreationGuiClickActions.java
+++ b/src/main/java/com/yusaki/lammailbox/gui/MailCreationGuiClickActions.java
@@ -92,7 +92,7 @@ final class MailCreationGuiClickActions {
         player.closeInventory();
         plugin.getAwaitingInput().put(player.getUniqueId(), "receiver");
         plugin.getMailCreationController().showInputTitle(player, "receiver");
-        player.sendMessage(plugin.colorize(config().getString("messages.enter-receiver")));
+        player.sendMessage(plugin.legacy(config().getString("messages.enter-receiver")));
     }
 
     private void handleMessagePaperClick(Player player) {
@@ -100,13 +100,13 @@ final class MailCreationGuiClickActions {
         player.closeInventory();
         plugin.getAwaitingInput().put(player.getUniqueId(), "message");
         plugin.getMailCreationController().showInputTitle(player, "message");
-        player.sendMessage(plugin.colorize(config().getString("messages.prefix") +
+        player.sendMessage(plugin.legacy(config().getString("messages.prefix") +
                 config().getString("messages.enter-message")));
     }
 
     private void handleItemsChestClick(Player player) {
         if (!player.hasPermission(config().getString("settings.permissions.add-items"))) {
-            player.sendMessage(plugin.colorize(config().getString("messages.no-permission")));
+            player.sendMessage(plugin.legacy(config().getString("messages.no-permission")));
             return;
         }
         plugin.openItemsGUI(player);
@@ -114,7 +114,7 @@ final class MailCreationGuiClickActions {
 
     private void handleCommandItemsClick(Player player) {
         if (!player.hasPermission(config().getString("settings.admin-permission"))) {
-            player.sendMessage(plugin.colorize(config().getString("messages.no-permission")));
+            player.sendMessage(plugin.legacy(config().getString("messages.no-permission")));
             return;
         }
         plugin.openCommandItemsEditor(player);
@@ -138,7 +138,7 @@ final class MailCreationGuiClickActions {
         String messageKey = awaitingKey.equals("expire-date")
                 ? "messages.enter-expire-date"
                 : "messages.enter-schedule-date";
-        player.sendMessage(plugin.colorize(config().getString("messages.prefix") +
+        player.sendMessage(plugin.legacy(config().getString("messages.prefix") +
                 config().getString(messageKey)));
     }
 

--- a/src/main/java/com/yusaki/lammailbox/gui/MailCreationViewBuilder.java
+++ b/src/main/java/com/yusaki/lammailbox/gui/MailCreationViewBuilder.java
@@ -52,7 +52,7 @@ final class MailCreationViewBuilder {
         ensureSessionDefaults(session);
 
         int size = config().getInt("gui.create-mail.size");
-        Inventory inv = Bukkit.createInventory(null, size, plugin.colorize(config().getString("gui.create-mail.title")));
+        Inventory inv = Bukkit.createInventory(null, size, plugin.legacy(config().getString("gui.create-mail.title")));
         decorationApplier.accept(inv, "gui.create-mail");
 
         addReceiverHead(inv, viewer, session);
@@ -67,7 +67,7 @@ final class MailCreationViewBuilder {
 
     Inventory createItemsEditor(Player viewer) {
         int size = config().getInt("gui.items.size");
-        Inventory inv = Bukkit.createInventory(null, size, plugin.colorize(config().getString("gui.items.title")));
+        Inventory inv = Bukkit.createInventory(null, size, plugin.legacy(config().getString("gui.items.title")));
 
         MailCreationSession session = plugin.getMailSessions().get(viewer.getUniqueId());
         if (session != null) {
@@ -78,9 +78,9 @@ final class MailCreationViewBuilder {
             ItemStack saveButton = new ItemStack(Material.valueOf(config().getString("gui.items.items.save-button.material")));
             ItemMeta saveMeta = saveButton.getItemMeta();
             if (saveMeta != null) {
-                saveMeta.setDisplayName(plugin.colorize(config().getString("gui.items.items.save-button.name")));
+                saveMeta.setDisplayName(plugin.legacy(config().getString("gui.items.items.save-button.name")));
                 saveMeta.setLore(config().getStringList("gui.items.items.save-button.lore").stream()
-                        .map(plugin::colorize)
+                        .map(plugin::legacy)
                         .collect(Collectors.toList()));
                 itemStyler.apply(saveMeta, "gui.items.items.save-button");
                 saveButton.setItemMeta(saveMeta);
@@ -99,7 +99,7 @@ final class MailCreationViewBuilder {
 
         String base = "gui.command-items-editor";
         int size = config().getInt(base + ".size", 45);
-        Inventory inv = Bukkit.createInventory(null, size, plugin.colorize(config().getString(base + ".title", "Command Items")));
+        Inventory inv = Bukkit.createInventory(null, size, plugin.legacy(config().getString(base + ".title", "Command Items")));
         decorationApplier.accept(inv, base);
 
         List<Integer> slots = config().getIntegerList(base + ".items.command-item.slots");
@@ -129,7 +129,7 @@ final class MailCreationViewBuilder {
         CommandItem.Builder draft = session.getCommandItemDraft();
         String base = "gui.command-item-creator";
         int size = config().getInt(base + ".size", 54);
-        Inventory inv = Bukkit.createInventory(null, size, plugin.colorize(config().getString(base + ".title", "Create Command Item")));
+        Inventory inv = Bukkit.createInventory(null, size, plugin.legacy(config().getString(base + ".title", "Create Command Item")));
         decorationApplier.accept(inv, base);
 
         Map<String, String> placeholders = new HashMap<>();
@@ -170,11 +170,11 @@ final class MailCreationViewBuilder {
         if (headMeta == null) {
             return;
         }
-        headMeta.setDisplayName(plugin.colorize(config().getString(path + ".name")));
+        headMeta.setDisplayName(plugin.legacy(config().getString(path + ".name")));
         List<String> headLore = viewer.hasPermission(config().getString("settings.admin-permission")) ?
                 config().getStringList(path + ".adminlore") :
                 config().getStringList(path + ".lore");
-        List<String> lore = headLore.stream().map(plugin::colorize).collect(Collectors.toList());
+        List<String> lore = headLore.stream().map(plugin::legacy).collect(Collectors.toList());
         if (session.getReceiver() != null) {
             lore.add(plugin.getMessage(path + ".current-receiver-format",
                     plugin.placeholders("receiver", session.getReceiver())));
@@ -195,14 +195,14 @@ final class MailCreationViewBuilder {
         if (paperMeta == null) {
             return;
         }
-        paperMeta.setDisplayName(plugin.colorize(config().getString(path + ".name")));
+        paperMeta.setDisplayName(plugin.legacy(config().getString(path + ".name")));
         List<String> paperLore = config().getStringList(path + ".lore").stream()
-                .map(plugin::colorize)
+                .map(plugin::legacy)
                 .collect(Collectors.toList());
         if (session.getMessage() != null) {
-            paperLore.add(plugin.colorize(config().getString(path + ".current-message-prefix")));
+            paperLore.add(plugin.legacy(config().getString(path + ".current-message-prefix")));
             paperLore.addAll(Arrays.stream(session.getMessage().split("\n"))
-                    .map(line -> plugin.colorize(config().getString(path + ".message-line-format") + line))
+                    .map(line -> plugin.legacy(config().getString(path + ".message-line-format") + line))
                     .collect(Collectors.toList()));
         }
         paperMeta.setLore(paperLore);
@@ -227,9 +227,9 @@ final class MailCreationViewBuilder {
         if (chestMeta == null) {
             return;
         }
-        chestMeta.setDisplayName(plugin.colorize(config().getString(path + ".name")));
+        chestMeta.setDisplayName(plugin.legacy(config().getString(path + ".name")));
         chestMeta.setLore(config().getStringList(path + ".lore").stream()
-                .map(plugin::colorize)
+                .map(plugin::legacy)
                 .collect(Collectors.toList()));
         itemStyler.apply(chestMeta, path);
         chest.setItemMeta(chestMeta);
@@ -246,9 +246,9 @@ final class MailCreationViewBuilder {
         if (sendMeta == null) {
             return;
         }
-        sendMeta.setDisplayName(plugin.colorize(config().getString(path + ".name")));
+        sendMeta.setDisplayName(plugin.legacy(config().getString(path + ".name")));
         sendMeta.setLore(config().getStringList(path + ".lore").stream()
-                .map(plugin::colorize)
+                .map(plugin::legacy)
                 .collect(Collectors.toList()));
         itemStyler.apply(sendMeta, path);
         sendButton.setItemMeta(sendMeta);
@@ -288,7 +288,7 @@ final class MailCreationViewBuilder {
             return clock;
         }
 
-        clockMeta.setDisplayName(plugin.colorize(config().getString(basePath + ".name")));
+        clockMeta.setDisplayName(plugin.legacy(config().getString(basePath + ".name")));
 
         String scheduleTime = session.getScheduleDate() != null
                 ? DATE_FORMAT.format(new Date(session.getScheduleDate()))
@@ -301,7 +301,7 @@ final class MailCreationViewBuilder {
                 .map(line -> plugin.applyPlaceholderVariants(line, Map.of(
                         "schedule_time", scheduleTime,
                         "expire_time", expireTime)))
-                .map(plugin::colorize)
+                .map(plugin::legacy)
                 .collect(Collectors.toList());
         clockMeta.setLore(lore);
         itemStyler.apply(clockMeta, basePath);
@@ -338,9 +338,9 @@ final class MailCreationViewBuilder {
                     if (meta == null) {
                         continue;
                     }
-                    meta.setDisplayName(plugin.colorize(config.getString(base + ".name", " ")));
+                    meta.setDisplayName(plugin.legacy(config.getString(base + ".name", " ")));
                     meta.setLore(config.getStringList(base + ".lore").stream()
-                            .map(plugin::colorize)
+                            .map(plugin::legacy)
                             .collect(Collectors.toList()));
                     filler.setItemMeta(meta);
                     return filler;

--- a/src/main/java/com/yusaki/lammailbox/gui/MailViewClickActions.java
+++ b/src/main/java/com/yusaki/lammailbox/gui/MailViewClickActions.java
@@ -158,7 +158,7 @@ final class MailViewClickActions {
         player.closeInventory();
         plugin.openMainGUI(player);
         String messageKey = hasRewards ? "messages.items-claimed" : "messages.no-items-in-mail";
-        player.sendMessage(plugin.colorize(config().getString("messages.prefix") +
+        player.sendMessage(plugin.legacy(config().getString("messages.prefix") +
                 config().getString(messageKey)));
     }
 

--- a/src/main/java/com/yusaki/lammailbox/gui/MainGuiClickActions.java
+++ b/src/main/java/com/yusaki/lammailbox/gui/MainGuiClickActions.java
@@ -49,7 +49,7 @@ final class MainGuiClickActions {
         if (isEnabled("gui.main.items.create-mail") &&
                 event.getSlot() == config().getInt("gui.main.items.create-mail.slot")) {
             if (isViewingAsOther(player)) {
-                player.sendMessage(plugin.colorize(config().getString("messages.prefix") +
+                player.sendMessage(plugin.legacy(config().getString("messages.prefix") +
                         config().getString("messages.cannot-create-as-other")));
                 return;
             }

--- a/src/main/java/com/yusaki/lammailbox/gui/PaginationBuilder.java
+++ b/src/main/java/com/yusaki/lammailbox/gui/PaginationBuilder.java
@@ -137,7 +137,7 @@ final class PaginationBuilder {
                         "total", String.valueOf(totalPages)
                 ));
             } else {
-                name = plugin.colorize(name);
+                name = plugin.legacy(name);
             }
             meta.setDisplayName(name);
         }

--- a/src/main/java/com/yusaki/lammailbox/model/CommandItem.java
+++ b/src/main/java/com/yusaki/lammailbox/model/CommandItem.java
@@ -65,11 +65,11 @@ public final class CommandItem {
             String name = displayName == null || displayName.isBlank()
                     ? "&6Console Action"
                     : displayName;
-            meta.setDisplayName(plugin.colorize(name));
+            meta.setDisplayName(plugin.legacy(name));
 
             List<String> displayLore = lore.isEmpty() ? Collections.emptyList() : lore;
             List<String> loreLines = displayLore.stream()
-                    .map(plugin::colorize)
+                    .map(plugin::legacy)
                     .toList();
             meta.setLore(loreLines);
             if (customModelData != null) {

--- a/src/main/java/com/yusaki/lammailbox/session/MailCreationController.java
+++ b/src/main/java/com/yusaki/lammailbox/session/MailCreationController.java
@@ -21,40 +21,55 @@ public class MailCreationController {
 
     public void showInputTitle(Player player, String type) {
         String path = "titles.input." + type;
-        String rawTitle = config().getString(path + ".title", config().getString("titles.input.command.title"));
-        String rawSubtitle = config().getString(path + ".subtitle", config().getString("titles.input.command.subtitle"));
-        String title = plugin.colorize(rawTitle != null ? rawTitle : "");
-        String subtitle = plugin.colorize(rawSubtitle != null ? rawSubtitle : "");
-        int fadeIn = config().getInt("titles.input.fadein");
-        int stay = config().getInt("titles.input.stay");
-        int fadeOut = config().getInt("titles.input.fadeout");
-        player.sendTitle(title, subtitle, fadeIn, stay, fadeOut);
+        String titleKey = config().contains(path + ".title") ? path + ".title" : "titles.input.command.title";
+        String subtitleKey = config().contains(path + ".subtitle") ? path + ".subtitle" : "titles.input.command.subtitle";
+
+        plugin.getYskLib().messageManager.sendTitle(
+                plugin,
+                player,
+                titleKey,
+                subtitleKey,
+                config().getInt("titles.input.fadein"),
+                config().getInt("titles.input.stay"),
+                config().getInt("titles.input.fadeout"),
+                Collections.emptyMap()
+        );
     }
 
     public void showResponseTitle(Player player, boolean success, String customSubtitle) {
         String type = success ? "success" : "error";
         String titlePath = "titles.response." + type;
-        String title = plugin.colorize(config().getString(titlePath + ".title"));
-        String subtitle = customSubtitle != null ?
-                plugin.colorize(customSubtitle) :
-                plugin.colorize(config().getString(titlePath + ".subtitle"));
-        int fadeIn = config().getInt("titles.response.fadein");
-        int stay = config().getInt("titles.response.stay");
-        int fadeOut = config().getInt("titles.response.fadeout");
-        player.sendTitle(title, subtitle, fadeIn, stay, fadeOut);
+
+        if (customSubtitle != null) {
+            String title = plugin.getYskLib().messageManager.getMessage(plugin, titlePath + ".title", Collections.emptyMap());
+            String subtitle = plugin.legacy(customSubtitle);
+            player.sendTitle(title, subtitle,
+                    config().getInt("titles.response.fadein"),
+                    config().getInt("titles.response.stay"),
+                    config().getInt("titles.response.fadeout"));
+        } else {
+            plugin.getYskLib().messageManager.sendTitle(
+                    plugin,
+                    player,
+                    titlePath + ".title",
+                    titlePath + ".subtitle",
+                    config().getInt("titles.response.fadein"),
+                    config().getInt("titles.response.stay"),
+                    config().getInt("titles.response.fadeout"),
+                    Collections.emptyMap()
+            );
+        }
     }
 
     public boolean handleReceiverInput(Player sender, String input, MailCreationSession session) {
         if (input.equalsIgnoreCase(sender.getName())) {
-            sender.sendMessage(plugin.colorize(config().getString("messages.prefix") +
-                    config().getString("messages.self-mail")));
+            plugin.sendPrefixedMessage(sender, "messages.self-mail");
             return false;
         }
 
         if (isBulkTarget(input)) {
             if (!sender.hasPermission(config().getString("settings.admin-permission"))) {
-                sender.sendMessage(plugin.colorize(config().getString("messages.prefix") +
-                        config().getString("messages.no-permission")));
+                plugin.sendPrefixedMessage(sender, "messages.no-permission");
                 return false;
             }
             session.setReceiver(input);
@@ -63,8 +78,7 @@ public class MailCreationController {
 
         int currentMails = plugin.getMailRepository().countActiveMailFor(input);
         if (currentMails >= config().getInt("settings.max-mails-per-player")) {
-            sender.sendMessage(plugin.colorize(config().getString("messages.prefix") +
-                    config().getString("messages.mailbox-full")));
+            plugin.sendPrefixedMessage(sender, "messages.mailbox-full");
             return false;
         }
 
@@ -81,7 +95,7 @@ public class MailCreationController {
     public boolean handleCommandItemMaterialInput(Player player, String input, MailCreationSession session) {
         CommandItem.Builder draft = ensureCommandItemDraft(session);
         if (input == null || input.trim().isEmpty()) {
-            player.sendMessage(plugin.colorize(prefix() + config().getString("messages.invalid-material")));
+            plugin.sendPrefixedMessage(player, "messages.invalid-material");
             return false;
         }
 
@@ -98,24 +112,23 @@ public class MailCreationController {
             }
         }
         if (material == null) {
-            player.sendMessage(plugin.colorize(prefix() + config().getString("messages.invalid-material")));
+            plugin.sendPrefixedMessage(player, "messages.invalid-material");
             return false;
         }
         draft.material(material.name());
-        String materialTemplate = config().getString("messages.command-item-material-set", "&a✔ Material set to %material%");
-        player.sendMessage(plugin.colorize(prefix() +
-                plugin.applyPlaceholderVariants(materialTemplate, "material", material.name())));
+        plugin.sendPrefixedMessage(player, "messages.command-item-material-set",
+                plugin.placeholders("material", material.name()));
         return true;
     }
 
     public boolean handleCommandItemNameInput(Player player, String input, MailCreationSession session) {
         CommandItem.Builder draft = ensureCommandItemDraft(session);
         if (input == null || input.trim().isEmpty()) {
-            player.sendMessage(plugin.colorize(prefix() + config().getString("messages.command-item-name-failed", "&c✖ Name update failed.")));
+            plugin.sendPrefixedMessage(player, "messages.command-item-name-failed");
             return false;
         }
         draft.displayName(input);
-        player.sendMessage(plugin.colorize(prefix() + config().getString("messages.command-item-name-set", "&a✔ Name updated.")));
+        plugin.sendPrefixedMessage(player, "messages.command-item-name-set");
         return true;
     }
 
@@ -123,37 +136,37 @@ public class MailCreationController {
         CommandItem.Builder draft = ensureCommandItemDraft(session);
         String trimmed = input == null ? "" : input.trim();
         if (trimmed.isEmpty()) {
-            player.sendMessage(plugin.colorize(prefix() + config().getString("messages.command-item-lore-failed", "&c✖ Lore update failed")));
+            plugin.sendPrefixedMessage(player, "messages.command-item-lore-failed");
             return false;
         }
         draft.addLoreLine(input);
-        player.sendMessage(plugin.colorize(prefix() + config().getString("messages.command-item-lore-added", "&a✔ Added lore line.")));
+        plugin.sendPrefixedMessage(player, "messages.command-item-lore-added");
         return true;
     }
 
     public boolean handleCommandItemCommandInput(Player player, String input, MailCreationSession session) {
         CommandItem.Builder draft = ensureCommandItemDraft(session);
         if (input == null || input.trim().isEmpty()) {
-            player.sendMessage(plugin.colorize(prefix() + config().getString("messages.command-item-command-failed", "&c✖ Command update failed")));
+            plugin.sendPrefixedMessage(player, "messages.command-item-command-failed");
             return false;
         }
         String trimmed = input.startsWith("/") ? input.substring(1) : input;
         draft.addCommand(trimmed);
-        player.sendMessage(plugin.colorize(prefix() + config().getString("messages.command-item-command-added", "&a✔ Added command.")));
+        plugin.sendPrefixedMessage(player, "messages.command-item-command-added");
         return true;
     }
 
     public boolean handleCommandItemCustomModelInput(Player player, String input, MailCreationSession session) {
         CommandItem.Builder draft = ensureCommandItemDraft(session);
         if (input == null) {
-            player.sendMessage(plugin.colorize(prefix() + config().getString("messages.command-item-model-invalid", "&c✖ Invalid custom model data.")));
+            plugin.sendPrefixedMessage(player, "messages.command-item-model-invalid");
             return false;
         }
 
         String trimmed = input.trim();
         if (trimmed.isEmpty() || trimmed.equalsIgnoreCase("clear") || trimmed.equalsIgnoreCase("none") || trimmed.equalsIgnoreCase("reset")) {
             draft.customModelData(null);
-            player.sendMessage(plugin.colorize(prefix() + config().getString("messages.command-item-model-cleared", "&a✔ Custom model data cleared.")));
+            plugin.sendPrefixedMessage(player, "messages.command-item-model-cleared");
             return true;
         }
 
@@ -163,12 +176,11 @@ public class MailCreationController {
                 throw new NumberFormatException("negative");
             }
             draft.customModelData(value);
-            String template = config().getString("messages.command-item-model-set", "&a✔ Custom model data updated.");
-            String formatted = plugin.applyPlaceholderVariants(template, "value", String.valueOf(value));
-            player.sendMessage(plugin.colorize(prefix() + formatted));
+            plugin.sendPrefixedMessage(player, "messages.command-item-model-set",
+                    plugin.placeholders("value", String.valueOf(value)));
             return true;
         } catch (NumberFormatException ex) {
-            player.sendMessage(plugin.colorize(prefix() + config().getString("messages.command-item-model-invalid", "&c✖ Invalid custom model data.")));
+            plugin.sendPrefixedMessage(player, "messages.command-item-model-invalid");
             return false;
         }
     }
@@ -176,12 +188,12 @@ public class MailCreationController {
     public boolean finalizeCommandItem(Player player, MailCreationSession session) {
         CommandItem.Builder draft = session.getCommandItemDraft();
         if (draft == null) {
-            player.sendMessage(plugin.colorize(prefix() + config().getString("messages.command-item-no-draft", "&c✖ Nothing to save.")));
+            plugin.sendPrefixedMessage(player, "messages.command-item-no-draft");
             return false;
         }
 
         if (draft.commands().isEmpty()) {
-            player.sendMessage(plugin.colorize(prefix() + config().getString("messages.command-item-requires-command", "&c✖ Add at least one command.")));
+            plugin.sendPrefixedMessage(player, "messages.command-item-requires-command");
             return false;
         }
 
@@ -196,7 +208,7 @@ public class MailCreationController {
         session.setCommandItems(items);
         session.setCommandItemDraft(null);
         session.setCommandItemEditIndex(null);
-        player.sendMessage(plugin.colorize(prefix() + config().getString("messages.command-item-saved", "&a✔ Command item saved!")));
+        plugin.sendPrefixedMessage(player, "messages.command-item-saved");
         return true;
     }
 
@@ -226,19 +238,16 @@ public class MailCreationController {
 
             if (isSchedule) {
                 session.setScheduleDate(timestamp);
-                String template = config().getString("messages.schedule-set");
-                String formatted = plugin.applyPlaceholderVariants(template, "date", calendar.getTime().toString());
-                player.sendMessage(plugin.colorize(config().getString("messages.prefix") + formatted));
+                plugin.sendPrefixedMessage(player, "messages.schedule-set",
+                        plugin.placeholders("date", calendar.getTime().toString()));
             } else {
                 session.setExpireDate(timestamp);
-                String template = config().getString("messages.expire-set");
-                String formatted = plugin.applyPlaceholderVariants(template, "date", calendar.getTime().toString());
-                player.sendMessage(plugin.colorize(config().getString("messages.prefix") + formatted));
+                plugin.sendPrefixedMessage(player, "messages.expire-set",
+                        plugin.placeholders("date", calendar.getTime().toString()));
             }
             return true;
         } catch (Exception e) {
-            player.sendMessage(plugin.colorize(config().getString("messages.prefix") +
-                    config().getString("messages.invalid-date-format")));
+            plugin.sendPrefixedMessage(player, "messages.invalid-date-format");
             return false;
         }
     }
@@ -273,7 +282,4 @@ public class MailCreationController {
         return draft;
     }
 
-    private String prefix() {
-        return config().getString("messages.prefix", "");
-    }
 }

--- a/src/main/java/com/yusaki/lammailbox/session/MailCreationController.java
+++ b/src/main/java/com/yusaki/lammailbox/session/MailCreationController.java
@@ -24,7 +24,7 @@ public class MailCreationController {
         String titleKey = config().contains(path + ".title") ? path + ".title" : "titles.input.command.title";
         String subtitleKey = config().contains(path + ".subtitle") ? path + ".subtitle" : "titles.input.command.subtitle";
 
-        plugin.getYskLib().messageManager.sendTitle(
+        plugin.getMessageManager().sendTitle(
                 plugin,
                 player,
                 titleKey,
@@ -41,14 +41,14 @@ public class MailCreationController {
         String titlePath = "titles.response." + type;
 
         if (customSubtitle != null) {
-            String title = plugin.getYskLib().messageManager.getMessage(plugin, titlePath + ".title", Collections.emptyMap());
+            String title = plugin.getMessageManager().getMessage(plugin, titlePath + ".title", Collections.emptyMap());
             String subtitle = plugin.legacy(customSubtitle);
             player.sendTitle(title, subtitle,
                     config().getInt("titles.response.fadein"),
                     config().getInt("titles.response.stay"),
                     config().getInt("titles.response.fadeout"));
         } else {
-            plugin.getYskLib().messageManager.sendTitle(
+            plugin.getMessageManager().sendTitle(
                     plugin,
                     player,
                     titlePath + ".title",

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -526,6 +526,7 @@ messages:
   enter-command-item-lore: '&eEnter lore line. Right-click the lore button to remove the last entry.'
   enter-command-item-command: '&eEnter command (without /). Right-click the command button to remove the last entry.'
   enter-command-item-custom-model: '&eEnter custom model data (number) or type CLEAR.'
+  command-format-display: '&7Command: &f%command%'
   incomplete-mail: '&c⚠ Cannot send mail - some details are missing!'
   current-receiver: '&a✉ Sending to: &f%receiver%'
   current-message: '&a✎ Your message:'

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -23,7 +23,7 @@ settings:
     pitch: 1.0
 
   command-aliases:
-    base: [mailbox, mail, mb]
+    lmb: [mailbox, mail, mb]
 
 mailings:
   auto-cleanup: true


### PR DESCRIPTION
### Summary

- Refactors message delivery across commands and GUI to use a unified, Adventure-based message API and consistent prefix handling
- Updates and centralizes all feedback, input, error, and title messages to leverage new message utilities for colorization and placeholder resolution
- Migrates command alias configuration to use a new `lmb` key, deprecating the legacy `base` key in config
- Integrates a dynamic CommandAliasManager for robust alias application, allowing primary command and aliases to be updated at runtime
- Bumps YskLib to version 1.6.6 to utilize improved message and alias APIs, and updates minimum dependency requirements accordingly
- Increments plugin version to 1.5.3
- Updates documentation (README) to reflect version and library changes

### Motivation

Unifying message logic improves maintainability and ensures consistent player/admin messaging throughout the codebase, while incorporating Adventure components for greater style flexibility. The switch to dynamic alias management and a more robust configuration structure prevents aliasing issues and improves user experience for both admins and plugin users.